### PR TITLE
Use 'x86' instead of 'x32'

### DIFF
--- a/.vitepress/theme/components/Win32.vue
+++ b/.vitepress/theme/components/Win32.vue
@@ -37,7 +37,7 @@
         <i class="icon">
           <div class="i-fa6-solid:box " />
         </i>
-        <span>{{ t("download-zip") }} (x32)</span>
+        <span>{{ t("download-zip") }} (x86)</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
Usually, people think 'x86' stands for 'i386' (or 'intel 80386') on Windows.

In my opinion, 'x86' means '32 bits' and 'x64' (or 'x86_64') means '64 bits'.