### PR TITLE
ci: bump Vercel CLI past 47.2.2 + refresh action versions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,17 +19,17 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           repository: voxelum/minecraft-launcher-core-node
           path: src/en/core
           ref: 'gh-pages'
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v4
         with:
           version: 9.3.0
       - name: Use Node.js 20
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: "Install"
@@ -53,9 +53,12 @@ jobs:
           skip_app_build: true
           skip_api_build: true
       - if: always()
-        uses: amondnet/vercel-action@v41.1.4
+        uses: amondnet/vercel-action@v42.3.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          # The Vercel deploy API rejects CLI < 47.2.2 since mid-May 2026.
+          # The action's bundled CLI (42.x) is too old, so pin to latest.
+          vercel-version: latest
           vercel-args: '--prod --archive=tgz ./.vitepress/dist'
           vercel-org-id: ${{ secrets.ORG_ID }}
           vercel-project-id: ${{ secrets.PROJECT_ID }}


### PR DESCRIPTION
Vercel deploy API rejects CLI < 47.2.2 since 2026-05-16; every push to master since #216 errored out (see run [26051708335](https://github.com/Voxelum/xmcl-page/actions/runs/26051708335) for example). The action's bundled CLI tops out at 42.x so pinning the action alone is not enough — added `vercel-version: latest` to install a fresh CLI from npm.

Drive-by: bumped the four actions about to trip the Node 20 deprecation (June 2026):

- `actions/checkout@v3` -> `@v4`
- `actions/setup-node@v2` -> `@v4`  
- `pnpm/action-setup@v2.0.1` -> `@v4`
- `amondnet/vercel-action@v41.1.4` -> `@v42.3.0`

After merge the next push (or a manual `workflow_dispatch`) should land a successful deploy.

Co-authored-by: Copilot