### PR TITLE
fix: add fallback theme config to root locale to fix missing nav bar

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -14,6 +14,9 @@ const localeConfig: LocaleConfig<DefaultTheme.Config> = {}
 for (const locale of locales) {
   localeConfig[locale] = loadTheme(resolve(src, locale), locale)
 }
+if (localeConfig['en']) {
+  localeConfig['root'] = localeConfig['en']
+}
 
 export default defineConfigWithTheme<DefaultTheme.Config>({
   title: "X Minecraft Launcher",


### PR DESCRIPTION
Nav bar didnt render corrrectly because the root locale configuration (which is loaded when visiting pages directly from the root path `/` or `/index.html` instead of a subdirectory like `/en/` or `/zh/`) was missing a `themeConfig`. 

When users or search crawlers bypassed server-side redirects and accessed `/index.html` directly, VitePress loaded this empty root context, resulting in a page without a header, navigation bar, or footer.

This PR fixes the issue by assigning the English locale configuration to the root path locale (`localeConfig['root'] = localeConfig['en']`). Now, pages loaded from the root path fall back to the English layout, restoring the navigation bar and footer.