### PR TITLE
i18n: add Brazilian Portuguese (pt-BR) translation

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -10,7 +10,7 @@ import { imagetools } from 'vite-imagetools'
 
 const src = resolve(__dirname, '../src')
 const files = readdirSync(src)
-const localesOrder = ['en', 'de', 'fr', 'pl', 'uk', 'ru', 'kk', 'ar', 'zh', 'zh-TW', 'ko', 'jp']
+const localesOrder = ['en', 'de', 'fr', 'pt', 'pl', 'uk', 'ru', 'kk', 'ar', 'zh', 'zh-TW', 'ko', 'jp']
 const locales = files
   .filter(f => f !== 'assets' && !f.endsWith('.md'))
   .sort((a, b) => {
@@ -42,6 +42,7 @@ const localeMetadata: Record<string, { hreflang: string; ogLocale: string }> = {
   kk: { hreflang: 'kk', ogLocale: 'kk_KZ' },
   ko: { hreflang: 'ko', ogLocale: 'ko_KR' },
   pl: { hreflang: 'pl', ogLocale: 'pl_PL' },
+  pt: { hreflang: 'pt-BR', ogLocale: 'pt_BR' },
   ru: { hreflang: 'ru', ogLocale: 'ru_RU' },
   uk: { hreflang: 'uk', ogLocale: 'uk_UA' },
   'zh-TW': { hreflang: 'zh-Hant', ogLocale: 'zh_TW' },

--- a/locales/pt.yml
+++ b/locales/pt.yml
@@ -1,0 +1,392 @@
+repository: Repositório do Código Fonte
+label: Português (Brasil)
+intro:
+  first:
+    body: Um launcher de Minecraft {openSource} com uma interface {modernUx}.
+    openSource: código aberto
+    modernUx: moderna
+  second:
+    body: Gerencie todos os seus {mods} de forma {diskEfficient}!
+    diskEfficient: eficiente em disco
+    mods: mods
+  description: >-
+    X Minecraft Launcher (XMCL) é um launcher moderno de Minecraft que permite
+    gerenciar seus recursos como modpacks, pacotes de recursos, mods,
+    shaders... Possui integração com Minecraft Forge, Fabric, Quilt,
+    CurseForge e Modrinth.
+launcher:
+  manage:
+    intro: Gerencie seu Minecraft com eficiência.
+  description: Um launcher de Minecraft simples, de código aberto e orientado a funcionalidades.
+downloadFor:
+  windows: 'Baixar para Windows:'
+  mac: 'Baixar para Mac:'
+  linux: 'Baixar para Linux:'
+guide: Guia
+protocol: Protocolo
+changelogs: Histórico de alterações
+outline: Nesta página
+coreDocument: Documentação principal
+blogs: Blog
+author: Contatar o autor
+download-zip: Zip
+download-zip-32: Zip (32 bits)
+download-appx: Pacote AppX
+download-appinstaller: Instalador de App
+download-portable: Portátil
+download-dmg: DMG
+download-snap: Snap
+download-appimage: AppImage
+download-deb: Deb
+download-rpm: RPM
+download-flathub: Flathub
+azure-source: Baixar via Azure
+azure-ms-source: Baixar via Azure Microsoft CDN
+github-source: Baixar via Github
+auto-source: Seleção automática de origem
+authSuccess: Sucesso!
+authSuccessTitle: Autorização bem-sucedida. Você será redirecionado de volta ao launcher!
+redirectHelperTitle: >-
+  Se não for redirecionado automaticamente, tente clicar no botão
+  "Abrir no Launcher".
+redirectHelperMessage: >-
+  Uma janela irá aparecer pedindo para abrir o launcher. Se não funcionar,
+  tente arrastar o botão para a janela do launcher!
+notWork: Não está funcionando?
+openInAppButton: Abrir no Launcher
+nothingWork: >-
+  Se nada funcionar, você pode baixar a versão mais recente do
+  launcher novamente.
+gameInstall:
+  title:
+    body: Sem mais preocupações com a {gameInstall}
+    gameInstall: Instalação do jogo
+  description: >-
+    O XMCL suporta a instalação do Minecraft original, Forge, Fabric e até
+    OptiFine, tudo em um só lugar! Você pode instalá-los diretamente no launcher.
+optimalDisk:
+  title:
+    body: Espaço em disco {optimal} com {massiveResources}
+    optimal: Ótimo
+    massiveResources: recursos massivos
+  description: >-
+    O XMCL armazena todos os mods, pacotes de recursos, shaders e modpacks em um único
+    local. Em vez de copiar arquivos para cada perfil, usa links físicos. Isso significa
+    que você nunca verá arquivos duplicados na pasta /mods, economizando muito espaço em disco.
+cleanWorkspace:
+  title:
+    body: Mantenha seu espaço de trabalho {clean} com múltiplos perfis
+    clean: organizado
+  description: >-
+    O XMCL tem suporte integrado para múltiplas instâncias. Você pode criar várias
+    instâncias facilmente e não precisar se preocupar com configurações de inicialização misturadas.
+communityIntegration:
+  title:
+    body: Integrado com {multipleCommunities}
+    multipleCommunities: múltiplas comunidades
+  description: >-
+    O XMCL tem suporte integrado para Curseforge e Modrinth. Também oferece a
+    possibilidade de usar contas de usuário personalizadas e sistemas de skins como o Blessing Skin.
+download-tarxz: Tar.xz
+download-linuxZip: Zip
+joinPeer: Entrar no grupo de {inviter}
+joinPeerDescription: >-
+  {inviter} te convidou para entrar no grupo {group} para jogar Minecraft
+  juntos! Você será redirecionado de volta ao launcher!
+fullChangelog: O que há de novo?
+privacy: Privacidade do Software
+prebuild:
+  history: Histórico de builds
+  historyDescription: Builds e lançamentos anteriores
+  download: Baixar prebuilds
+  downloadDescription: >-
+    Prebuilds são artefatos gerados durante o desenvolvimento. Podem ser
+    instáveis. Use por sua conta e risco!
+  entryHint: Artefatos de prebuild?
+  ready: Pronto
+  selected: Selecionado
+  selectBuild: Selecionar build
+  downloading: Baixando...
+  kicker: CANAL DE PREBUILD
+  developmentBuilds: BUILDS DE DESENVOLVIMENTO
+  tryNext: Experimente o que vem por aí.
+  unstableDescription: Artefatos instáveis para testar as próximas mudanças do XMCL.
+  selectedBuild: BUILD SELECIONADA
+  buildsAvailable: '{count} builds disponíveis'
+  selectABuild: SELECIONAR UMA BUILD
+  noBuilds: NENHUMA BUILD ENCONTRADA
+  noBuildsDescription: Não há artefatos de prebuild disponíveis no momento.
+  checkBack: Volte após o próximo workflow de desenvolvimento ser concluído.
+  yesterday: Ontem
+  daysAgo: 'há {count} dias'
+downloadMacHint:
+  content: Para usuários de Mac, siga as {link} para instalar.
+  link: instruções de instalação
+features:
+  label: Funcionalidades
+  ui:
+    kicker: XMCL / CATÁLOGO DE FUNCIONALIDADES
+    heading: O launcher, mapeado.
+    description: Explore os fluxos de trabalho que tornam uma instalação modificada do Minecraft mais fácil de criar, entender e compartilhar.
+    all: Todas as funcionalidades
+    search: Buscar funcionalidades...
+    features: funcionalidades
+    featuresInView: funcionalidades visíveis
+    readWorkflow: Ver o fluxo de trabalho
+  status:
+    homepage: Início
+    catalog: Catálogo
+    guide: Guia
+    detail: Detalhes
+  groups:
+    instances:
+      short: Instâncias
+      title: Instâncias e perfis
+      description: Mantenha cada configuração do Minecraft independente, visível e pronta para iniciar.
+    community:
+      short: Comunidade
+      title: Mods e conteúdo da comunidade
+      description: Descubra, inspecione e instale os projetos que transformam uma versão do Minecraft no seu próximo mundo.
+    mods:
+      short: Controle de mods
+      title: Gerenciamento de mods
+      description: Mantenha uma instalação grande organizada com busca, agrupamento, verificação de dependências e atualizações controladas.
+    world-tools:
+      short: Ferramentas de mundo
+      title: Ferramentas de mundo
+      description: Trabalhe com os mundos das suas instâncias, inspecione sua forma, selecione partes e entenda seus materiais.
+    sharing:
+      short: Compartilhar
+      title: Compartilhamento e multijogador
+      description: Mova uma configuração funcionando para um amigo, servidor ou outra instalação com todos os detalhes intactos.
+    accounts:
+      short: Contas
+      title: Contas e produtividade
+      description: Mantenha identidade, personalização e ações frequentes próximas dos mundos que você joga.
+    diagnostics:
+      short: Diagnóstico
+      title: Diagnóstico e assistência
+      description: Quando uma inicialização falha, o XMCL coloca as evidências e a próxima ação no mesmo lugar.
+  items:
+    instance-library:
+      title: Uma biblioteca de instâncias organizada
+      benefit: Veja mundos vanilla, modificados e experimentais juntos em um só lugar pronto para jogar.
+      capabilities: Separar versões e loaders|Ver mods, mundos e recursos rapidamente|Iniciar a configuração desejada
+    instance-create-modloaders:
+      title: Criar instâncias Java e Bedrock
+      benefit: Comece uma nova configuração com o loader e a edição que combinam com o mundo que você quer jogar.
+      capabilities: Java Edition e suporte experimental ao Bedrock|Forge, Fabric, Quilt, NeoForge, OptiFine e LabyMod|Fontes do Minecraft e versões locais
+    instance-folder-groups:
+      title: Grupos de instâncias por pastas
+      benefit: Organize muitas instâncias em pastas para que diferentes mundos e configurações sejam fáceis de encontrar.
+      capabilities: Agrupar instâncias por propósito ou projeto|Manter configurações relacionadas juntas|Alternar entre pastas na barra lateral
+    instance-settings:
+      title: Configurações da instância
+      benefit: Ajuste Java, memória, versões, loaders e comportamento de inicialização sem afetar outras instâncias.
+      capabilities: Configuração independente por instância|Seleção de versão e loader|Controles de aparência por instância
+    instance-theme:
+      title: Tema da instância
+      benefit: Dê a cada mundo sua própria identidade com planos de fundo, cores, desfoque, fontes e CSS personalizado.
+      capabilities: Imagem de fundo e overlay|Cantos arredondados e fontes|Exportar e importar tema
+    local-server:
+      title: Iniciar um servidor local
+      benefit: Transforme uma instância em um servidor local configurável com mundo, limite de jogadores e arquivos exportáveis.
+      capabilities: MOTD, porta e limite de jogadores|Seleção de mundo e arquivos do servidor|Exportar um pacote de servidor
+    server-list:
+      title: Lista de servidores
+      benefit: Mantenha destinos multijogador próximos à instância correspondente e veja o estado da conexão.
+      capabilities: Status do servidor e contagem de jogadores|Fixar e remover destinos|Mostrar falhas de conexão claramente
+    modpack-market:
+      title: Mercado de modpacks
+      benefit: Navegue por conteúdo do Modrinth, CurseForge e FTB em um único marketplace pesquisável.
+      capabilities: Filtros de fonte, versão, loader e categoria|Descoberta de packs populares e recentes|Abrir página de detalhes de um pack
+    online-mod-search:
+      title: Busca de mods online
+      benefit: Encontre mods compatíveis nas principais plataformas antes de adicioná-los à sua instância.
+      capabilities: Fontes Modrinth e CurseForge|Filtros de versão e loader|Filtros de ambiente e categoria
+    modpack-detail:
+      title: Detalhes do modpack
+      benefit: Entenda um pack antes de instalá-lo, de capturas de tela e autores a requisitos técnicos.
+      capabilities: Capturas de tela, tags e estatísticas|Ações de instalar e iniciar|Informações técnicas e recursos externos
+    mod-collections:
+      title: Coleções de mods
+      benefit: Salve projetos para revisitar e transforme uma coleção em uma configuração reutilizável.
+      capabilities: Coleções do launcher|Projetos seguidos no Modrinth|Instalação em lote e gerenciamento de coleções
+    mod-detail:
+      title: Detalhes do mod
+      benefit: Inspecione um mod antes de alterar sua instância e entenda suas versões, dependências e fontes.
+      capabilities: Seleção de versão e dependências|Loaders, categorias e links de fonte|Descrição e recursos externos
+    local-mods:
+      title: Gerenciamento de mods instalados
+      benefit: Veja o que está ativo, filtre rapidamente e mantenha o conjunto funcionando saudável.
+      capabilities: Buscar, ordenar e filtrar mods|Verificar dependências e conteúdo não utilizado|Escolher política de atualização
+    custom-mod-groups:
+      title: Grupos de mods personalizados
+      benefit: Crie seus próprios grupos e salve as regras que organizam uma instância complexa.
+      capabilities: Aplicar e salvar regras de agrupamento|Agrupar mods pelo menu de contexto|Ativar, desativar ou inspecionar arquivos
+    save-preview:
+      title: Prévia de saves e ferramentas de chunks
+      benefit: Leia um mundo visualmente antes de iniciá-lo e faça mudanças precisas em nível de chunk.
+      capabilities: Navegar e inspecionar mapas do mundo|Selecionar, copiar ou excluir chunks|Ler propriedades e materiais do mundo
+    blueprint-preview:
+      title: Prévia de blueprints
+      benefit: Pré-visualize uma estrutura em 3D e verifique compatibilidade e materiais antes de colocá-la no jogo.
+      capabilities: Formatos Litematica e WorldEdit|Status de compatibilidade e mods ausentes|Lista de materiais e conversão de formato
+    modpack-export:
+      title: Exportar modpack
+      benefit: Empacote uma instância para outros jogadores sem perder os metadados e arquivos que a fazem funcionar.
+      capabilities: Exportação para CurseForge e Modrinth|Metadados de autor, descrição e URL|Escolher arquivos e assets a incluir
+    server-export:
+      title: Exportar servidor
+      benefit: Selecione o mundo e os arquivos do servidor certos, então exporte um servidor local com configuração clara.
+      capabilities: Exportar para uma pasta ou fazer upload|Selecionar arquivos do servidor|Configurar MOTD e opções do servidor
+    account-login:
+      title: Múltiplos serviços de autenticação
+      benefit: Escolha o serviço de conta que combina com a sua forma de jogar, da Microsoft ao offline e serviços de terceiros.
+      capabilities: Contas Microsoft e offline|Serviços Ely.by e LittleSkin|Adicionar e gerenciar serviços de autenticação
+    quick-action:
+      title: Ação rápida
+      benefit: Encontre instâncias e comandos sem sair da página em que você está.
+      capabilities: Buscar comandos, instâncias e mods|Iniciar ou criar uma instância|Navegação por teclado com Ctrl+K
+    crash-diagnosis:
+      title: Relatórios de crash e falhas de inicialização
+      benefit: Leia os logs reais, relatórios de crash e saída do servidor por trás de uma inicialização falha.
+      capabilities: Logs, relatórios de crash e falhas de inicialização|Erros de resolução de mods e códigos de saída|Copiar um prompt para ferramentas de IA externas
+    ai-agent:
+      title: Agente de IA integrado
+      benefit: Deixe um agente inspecionar o sistema de arquivos virtual da instância e explicar uma correção acionável.
+      capabilities: Ler arquivos e relatórios da instância|Investigar antes de concluir|Aplicar uma correção quando possível
+modernHome:
+  kicker: LAUNCHER DE MINECRAFT DE CÓDIGO ABERTO
+  visualLabel: FEITO PARA MUNDOS MODIFICADOS
+  windowLabel: XMCL / INÍCIO
+  latestRelease: ÚLTIMO LANÇAMENTO
+  readyToPlay: PRONTO PARA JOGAR
+  libraryTitle: Uma biblioteca limpa
+  librarySubtitle: Mods, packs e instâncias
+  proofLabel: Capacidades do launcher
+  proof:
+    fastTitle: CONFIGURAÇÃO RÁPIDA
+    fastDescription: De vanilla a modificado
+    libraryTitle: UMA BIBLIOTECA
+    libraryDescription: Recursos organizados
+    ecosystemTitle: SEU ECOSSISTEMA
+    ecosystemDescription: Modrinth e CurseForge
+  workflow:
+    kicker: O FLUXO DO XMCL
+    title: Tudo o que seus mundos precisam.
+    description: Projetado para jogadores que querem o poder de uma instalação modificada sem o overhead de manutenção.
+    stageLabel: XMCL / FLUXO DE TRABALHO
+    scrollHint: ROLE PARA EXPLORAR
+  openSource:
+    kicker: PULSO OPEN SOURCE
+    title: Construído em público.
+    viewOnGitHub: Ver no GitHub
+    repository: REPOSITÓRIO NO GITHUB
+    snapshot: SNAPSHOT DE BUILD
+    downloads: Downloads
+    stars: Estrelas
+    forks: Forks
+    openIssues: Issues abertas
+    statsNote: Dados do projeto no GitHub capturados quando este site foi gerado.
+    contributors: CONTRIBUIDORES
+    inView: EM VISTA
+    contributorsCopy: Cada issue, pull request, tradução e ideia ajuda a moldar o próximo lançamento.
+  sponsor:
+    label: APOIE O XMCL
+    title: Mantenha o launcher em movimento.
+    description: Apoie a manutenção, os lançamentos e as pessoas que constroem o XMCL em público.
+    supportedBy: APOIADO POR
+  download:
+    kicker: SUA PRÓXIMA AVENTURA
+    title: Pronto quando você estiver.
+    platforms: Plataformas de download
+  footer:
+    issues: Issues
+  features:
+    setup:
+      title: Cada configuração, um launcher
+      short: Multi-loader, multi-instância
+      description: Crie e gerencie instâncias separadas do Minecraft com Forge, Fabric, Quilt, NeoForge, OptiFine, LabyMod e suporte experimental ao Bedrock, com a instalação cuidada para você.
+      alt: Diálogo de Criar Jogo do XMCL com múltiplos Mod Loaders e Bedrock Edition
+      link: Explorar configuração de instâncias
+    discover:
+      title: Encontre conteúdo da comunidade
+      short: Modrinth, CurseForge e FTB
+      description: Navegue por modpacks e projetos da comunidade, filtre por versão e loader, e vá da descoberta ao jogo.
+      alt: Mercado de modpacks do XMCL com filtros de conteúdo da comunidade
+      link: Explorar conteúdo da comunidade
+    mods:
+      title: Mantenha as instalações modificadas sob controle
+      short: Buscar, agrupar, atualizar
+      description: Gerencie mods instalados, inspecione dependências, organize grupos personalizados e mantenha uma instalação grande compreensível.
+      alt: Gerenciamento de mods local do XMCL com filtros e controles de atualização
+      link: Explorar gerenciamento de mods
+    accounts:
+      title: Suas contas, do seu jeito
+      short: Microsoft, offline e mais
+      description: Conecte o serviço de conta que se encaixa na sua instalação, de perfis Microsoft e offline a serviços de autenticação de terceiros, sem sair do launcher.
+      alt: Diálogo de login de conta do XMCL com múltiplos serviços de autenticação
+      link: Explorar suporte a contas
+siteFooter:
+  ariaLabel: Rodapé do site
+  navigation: Navegação do rodapé
+  description: Infraestrutura Minecraft de código aberto para jogadores, desktops Linux e as pessoas que constroem os mundos que jogamos.
+  status: Código aberto · construído em público
+  explore:
+    title: Explorar
+    home: Início
+    features: Catálogo de funcionalidades
+    documentation: Documentação
+  useCases:
+    title: Casos de uso
+    linux: Launcher para Linux
+    creators: Criadores de modpacks
+    download: Baixar XMCL
+  resources:
+    title: Recursos
+    logViewer: Visualizador de logs
+    github: GitHub
+    issue: Reportar um problema
+    discord: Discord
+  bottomNote: Feito para a forma como você joga e cria.
+  readDocumentation: Ler a documentação
+sceneLanding:
+  linux:
+    eyebrow: XMCL / EDIÇÃO LINUX
+    title: O launcher de Minecraft que parece nativo no Linux.
+    lede: Um launcher de código aberto e polido para desktops Linux e Steam Deck. Escolha o pacote que sua distribuição espera e mantenha cada mundo a um clique de distância.
+    primaryAction: Baixar para Linux
+    secondaryAction: Ver o fluxo Linux
+    heroNote: Builds nativos para Linux, opções ARM64 e suporte ao Flathub
+    visualLabel: XMCL · espaço de trabalho Linux
+    heroAlt: Tela inicial do X Minecraft Launcher mostrando uma biblioteca de instâncias do Minecraft
+    visualTag: Espaço de trabalho pronto para 4K
+    visualStatus: PRONTO PARA SEU PRÓXIMO MUNDO
+    workflowKicker: UM FLUXO LINUX-FIRST
+    workflowTitle: Do gerenciador de pacotes ao jogo sem fricção.
+    workflowDescription: 'O XMCL mantém o que os jogadores Linux se importam próximo: instalações previsíveis, uma interface clara e ambientes de jogo independentes.'
+    signals:
+      packages: { number: '05', label: 'Pacotes Linux', description: 'DEB, RPM, AppImage, tar.xz e Flathub.' }
+      scale: { number: '4K', label: 'Claro em qualquer escala', description: 'Uma biblioteca densa que permanece legível em telas grandes.' }
+      worlds: { number: '∞', label: 'Mundos separados', description: 'Versões, loaders e saves não se misturam.' }
+    download: { kicker: 'BAIXAR PARA LINUX', title: 'Instale o XMCL do seu jeito.', description: 'Escolha o pacote que pertence ao seu sistema, ou use o Flathub para o Steam Deck.', link: 'Ver todos os lançamentos e prebuilds' }
+  creators:
+    eyebrow: XMCL / PARA CRIADORES DE MODPACKS
+    title: Crie modpacks com todo o ciclo de lançamento em um só lugar.
+    lede: Descubra projetos, resolva dependências, teste uma configuração, diagnostique crashes e exporte um pack limpo para Modrinth ou CurseForge sem sair do launcher.
+    primaryAction: Explorar fluxos de criadores
+    secondaryAction: Abrir o catálogo de funcionalidades
+    heroNote: Fluxos Modrinth e CurseForge, com diagnóstico assistido por IA
+    visualLabel: XMCL · espaço de trabalho do criador
+    heroAlt: Mercado de modpacks do X Minecraft Launcher com projetos do Modrinth e CurseForge
+    visualTag: MODRINTH ↔ CURSEFORGE
+    visualStatus: CONJUNTO DE TRABALHO SINCRONIZADO
+    workflowKicker: O CICLO DO CRIADOR
+    workflowTitle: Um caminho mais rápido de uma ideia bruta a um pack que os jogadores podem iniciar.
+    workflowDescription: 'O XMCL trata um modpack como um sistema vivo. Explore ambos os catálogos, faça mudanças deliberadas e deixe o launcher revelar os relacionamentos que mantêm seu lançamento saudável.'
+    signals:
+      sources: { number: '2×', label: 'Fontes de projetos', description: 'Busque Modrinth e CurseForge em um único espaço.' }
+      export: { number: '1 CLIQUE', label: 'Exportação do pack', description: 'Crie um pacote MR ou CF distribuível em poucos passos.' }
+      ai: { number: 'IA', label: 'Assistência a crashes', description: 'Transforme um relatório de falha em uma próxima ação útil.' }
+    cta: { kicker: 'UMA BANCADA PARA SEU PRÓXIMO LANÇAMENTO', title: 'Crie o pack. Lance o pack. Mantenha-o saudável.', description: 'O XMCL dá aos criadores um ciclo local rápido para descoberta, testes, diagnóstico e exportação nos dois ecossistemas que seus jogadores já usam.', button: 'Explorar todas as funcionalidades' }

--- a/src/pt/features/index.md
+++ b/src/pt/features/index.md
@@ -1,0 +1,6 @@
+---
+title: Funcionalidades do XMCL
+description: Explore os fluxos de trabalho e capacidades do X Minecraft Launcher.
+---
+
+<FeatureExplorer />

--- a/src/pt/guide/bedrock.md
+++ b/src/pt/guide/bedrock.md
@@ -1,0 +1,57 @@
+# Guia do Minecraft Bedrock Edition
+
+O X Minecraft Launcher (XMCL) suporta gerenciar, baixar e iniciar o **Minecraft Bedrock Edition** (também conhecido como *Edição Windows 10/11* ou *Edição UWP*).
+
+Este guia explica como configurar o Bedrock Edition no XMCL, de onde vêm os downloads dos pacotes e a compatibilidade com sistemas operacionais.
+
+---
+
+## 1. Requisitos do Sistema & Configuração (Apenas Windows)
+
+O Minecraft Bedrock Edition utiliza a arquitetura de pacotes UWP (Universal Windows Platform) do Windows (`Microsoft.MinecraftUWP`).
+
+### Passo 1: Ativar o Modo Desenvolvedor do Windows
+Para permitir que o XMCL alterne e registre pacotes de versão do Bedrock extraídos no seu sistema sem baixar novamente da Microsoft Store a cada vez:
+
+1. Pressione `Win + I` para abrir as **Configurações do Windows**.
+2. Vá em **Privacidade & Segurança** (ou *Sistema*) -> **Para desenvolvedores**.
+3. Ative o **Modo Desenvolvedor** para **LIGADO**.
+4. Confirme o prompt do Windows.
+
+:::warning Requisito de Licença da Microsoft
+Você deve possuir uma licença válida do **Minecraft Bedrock Edition** na sua conta Microsoft (ou ter baixado o Bedrock da Microsoft Store) para jogar as versões de lançamento completas. As builds Beta/Preview requerem uma conta Microsoft registrada no programa Insider Beta.
+:::
+
+---
+
+## 2. Instalando & Iniciando Versões Bedrock no XMCL
+
+1. Abra o **X Minecraft Launcher**.
+2. Clique em **Criar Instância** ou abra as **Configurações da Instância**.
+3. Mude o tipo de jogo / edição para **Bedrock Edition**.
+4. No seletor de versão, navegue pela lista de builds de lançamento, beta ou preview disponíveis.
+5. Clique em **Instalar**. O XMCL buscará o pacote da versão e o extrairá para sua pasta de dados local.
+6. Clique em **Iniciar**. O XMCL registrará dinamicamente a versão com os serviços AppX do Windows e iniciará o jogo.
+
+---
+
+## 3. De Onde Vêm os Pacotes Bedrock?
+
+Todos os arquivos de versão e metadados do Bedrock acessados pelo XMCL são obtidos diretamente da infraestrutura oficial:
+
+- **Banco de Dados de Versões (`mrarm.io/r/w10-vdb`)**: Fornece uma lista indexada de GUIDs de versões públicas de lançamento e preview (Identidades de Atualização).
+- **Downloads de Pacotes (`tlu.dl.delivery.mp.microsoft.com`)**: Os binários dos pacotes (`.appx`) são baixados diretamente da **CDN oficial do Windows Update da Microsoft**. O XMCL não hospeda nem redistribui arquivos do jogo.
+
+---
+
+## 4. Compatibilidade de Plataforma (Windows vs. macOS vs. Linux)
+
+| Sistema Operacional | Status de Compatibilidade | Detalhes |
+| :--- | :--- | :--- |
+| 💻 **Windows 10 / 11** | ✅ **Totalmente Suportado** | Ambiente de runtime UWP nativo. A troca de versão e inicialização funcionam perfeitamente. |
+| 🍎 **macOS** | ❌ **Não Suportado** | O Bedrock no XMCL depende de APIs AppX/UWP específicas do Windows (`Get-AppxPackage`). No macOS, jogue **Java Edition** nativamente ou use wrappers Android independentes fora do XMCL. |
+| 🐧 **Linux** | ❌ **Não Suportado** | O gerenciamento de pacotes UWP é exclusivo do Windows. No Linux, jogue **Java Edition** nativamente ou use ferramentas independentes como `mcpelauncher` (APK Android) fora do XMCL. |
+
+:::info Jogando no macOS & Linux
+Se você está no macOS ou Linux, recomendamos fortemente jogar **Minecraft Java Edition** no XMCL, que é 100% multiplataforma, suporta milhares de mods, shaders personalizados e cross-play com servidores Java!
+:::

--- a/src/pt/guide/change-drive.md
+++ b/src/pt/guide/change-drive.md
@@ -1,0 +1,57 @@
+# Como Mover o XMCL & Dados do Jogo para Outro Drive
+
+Ao instalar o X Minecraft Launcher ou baixar muitas versões do Minecraft, mods, pacotes de recursos e shaders, o drive do sistema (`C:`) pode rapidamente ficar sem espaço.
+
+Este guia explica como **mover o aplicativo do launcher** e **relocar os dados do jogo Minecraft** para um drive secundário (como `D:` ou `E:`).
+
+:::tip Recomendação Rápida
+Se você só quer liberar espaço em disco no `C:`, você só precisa **[Mudar o Diretório de Dados do Jogo](#1-relocando-os-dados-do-jogo-minecraft-recomendado)** dentro do XMCL. Os dados do jogo (mods, saves, versões) representam 99% do espaço utilizado!
+:::
+
+---
+
+## 1. Relocando os Dados do Jogo Minecraft (Recomendado)
+
+O XMCL permite armazenar todos os arquivos pesados do Minecraft (versões, mods, instâncias, pacotes de recursos, assets) em qualquer drive sem reinstalar o launcher.
+
+### Passos para Mudar o Diretório de Dados:
+1. Inicie o **X Minecraft Launcher**.
+2. Abra as **Configurações** (clique no ícone de engrenagem ⚙️ no canto inferior esquerdo).
+3. Vá em **Configurações Globais** -> **Geral / Armazenamento**.
+4. Encontre a configuração **Diretório de Dados / Caminho**.
+5. Clique em **Procurar** / **Mudar Caminho** e selecione uma pasta no drive desejado (ex: `D:\XMCL-Data` ou `E:\MinecraftData`).
+6. Confirme a seleção. O XMCL usará automaticamente o novo local para todas as instâncias, mods e downloads atuais e futuros do Minecraft!
+
+---
+
+## 2. Movendo o Binário do Aplicativo do Launcher
+
+Dependendo de qual formato de pacote você usou para instalar o XMCL, mover o executável do launcher requer métodos diferentes:
+
+### Opção A: Pacote ZIP Portátil
+- **Características**: Totalmente portátil e independente.
+- **Como mover**:
+  1. Feche o XMCL se estiver em execução.
+  2. Simplesmente copie ou recorte e cole a pasta `XMCL` extraída de `C:\` para o novo drive (ex: `D:\Games\XMCL`).
+  3. Execute `xmcl.exe` diretamente do novo diretório. Você pode criar um atalho na área de trabalho a partir do `xmcl.exe`.
+
+### Opção B: AppX / AppInstaller Online / WinGet
+- **Por que a cópia simples não funciona**: AppX, AppInstaller e WinGet instalam o XMCL como um pacote Windows sandboxed em caminhos de sistema protegidos (`C:\Program Files\WindowsApps` e `%LocalAppData%\Packages`). Copiar manualmente essas pastas no Explorador de Arquivos causará erros de permissão do Windows.
+- **Como mover usando as Configurações do Windows**:
+  1. Pressione `Win + I` para abrir as **Configurações do Windows**.
+  2. Navegue até **Aplicativos** -> **Aplicativos instalados** (ou *Apps e recursos*).
+  3. Pesquise por **X Minecraft Launcher**.
+  4. Clique nos três pontos `...` ao lado do XMCL e selecione **Mover**.
+  5. Selecione o drive de destino (ex: `D:`) na lista suspensa e clique em **Mover**. O Windows transferirá de forma limpa o binário do aplicativo e seus dados do sandbox para o drive selecionado.
+
+:::tip Mudar o Local Padrão de Instalação AppX do Windows
+Para fazer futuros aplicativos AppX / WinGet instalarem em outro drive por padrão:
+Abra **Configurações** -> **Sistema** -> **Armazenamento** -> **Configurações avançadas de armazenamento** -> **Onde o novo conteúdo é salvo** -> Mude *Novos aplicativos serão salvos em:* para o drive `D:`.
+:::
+
+### Opção C: macOS (DMG)
+- Arraste `X Minecraft Launcher.app` de `/Aplicativos` para qualquer volume de disco conectado, ou mantenha o app em `/Aplicativos` enquanto muda o Diretório de Dados do Jogo dentro das configurações do launcher para um drive externo.
+
+### Opção D: Linux (AppImage / Flatpak / Deb / RPM)
+- Para **AppImage**, simplesmente mova o arquivo `.AppImage` para qualquer partição montada (ex: `/media/data/XMCL.AppImage`).
+- Para **Deb / RPM / Flatpak**, os binários do sistema permanecem nos caminhos padrão do sistema, mas todos os assets pesados do jogo podem ser direcionados para outro drive usando a **Seção 1**.

--- a/src/pt/guide/contributing.md
+++ b/src/pt/guide/contributing.md
@@ -1,0 +1,245 @@
+# Contribuindo com o X Minecraft Launcher (XMCL)
+
+Obrigado pelo seu interesse em contribuir com o XMCL! Este guia fornece uma visão geral da stack tecnológica, arquitetura monorepo, configuração do ambiente de desenvolvimento, configurações de editores (**VS Code**, **Zed Editor**, **Neovim / Vim**, **Helix**, **JetBrains**), fluxos de debug, procedimentos de teste e padrões de submissão.
+
+---
+
+## 1. Stack Tecnológica & Infraestrutura
+
+O XMCL é construído como um monorepo modular alimentado por tecnologias modernas de web e desktop:
+
+### Core Global & Monorepo
+- **[Node.js](https://nodejs.org/) (>= 20)**: Ambiente de runtime principal.
+- **[pnpm](https://pnpm.io/)**: Gerenciador de pacotes do monorepo usando workspaces `pnpm`.
+- **[TypeScript](https://www.typescriptlang.org/) (v5.9+)**: Tipagem estática rigorosa em todos os módulos.
+
+### Processo Principal (Backend Electron)
+- **[Electron 43](https://electronjs.org/)**: Container da aplicação desktop.
+- **[esbuild](https://esbuild.github.io/)**: Bundler de alto desempenho para código TypeScript do processo principal.
+- **Módulos Nativos**: `node-datachannel` (multijogador P2P WebRTC), `@xmcl/windows-utils`.
+
+### Processo de Renderização (UI Frontend)
+- **[Vue 3](https://vuejs.org/)**: Framework progressivo para interfaces de usuário (Composition API `<script setup>`).
+- **[Vite](https://vitejs.dev/)**: Ferramenta de build frontend extremamente rápida e servidor HMR.
+- **[Vuetify 3](https://vuetifyjs.com/)**: Biblioteca de componentes Material Design.
+
+### Testes & Qualidade de Código
+- **[Vitest](https://vitest.dev/)**: Framework de testes unitários.
+- **[Oxlint](https://oxc.rs/)**: Linter JavaScript/TypeScript de alto desempenho.
+
+---
+
+## 2. Estrutura de Diretórios do Monorepo
+
+```sh
+x-minecraft-launcher
+ ├─ 📂 packages/               # Pacotes TypeScript independentes do core
+ │   ├─ 📂 core/               # Inicialização do jogo, parse de versões, resolução de Java
+ │   ├─ 📂 installer/          # Downloads, instaladores do Minecraft/Forge/Fabric/NeoForge
+ │   ├─ 📂 curseforge/         # Integração com a API do CurseForge
+ │   ├─ 📂 modrinth/           # Integração com a API do Modrinth
+ │   ├─ 📂 user/               # Autenticação Yggdrasil & Authlib-injector
+ │   └─ 📂 wrtc-multiplayer/   # Rede P2P multiplayer WebRTC DataChannel
+ ├─ 📂 xmcl-runtime/           # Serviços de backend & controladores IPC (JavaService, InstanceService, etc.)
+ ├─ 📂 xmcl-runtime-api/       # Interfaces TypeScript compartilhadas & contratos de eventos IPC
+ ├─ 📂 xmcl-keystone-ui/       # Interface de usuário frontend Vue 3 / Vite
+ └─ 📂 xmcl-electron-app/      # Ponto de entrada do processo principal Electron & empacotamento nativo
+```
+
+---
+
+## 3. Primeiros Passos & Configuração Local
+
+### Passo 1: Clonar o Repositório
+Clone com submódulos usando a flag `--recurse-submodules`:
+```sh
+git clone --recurse-submodules https://github.com/Voxelum/x-minecraft-launcher.git
+cd x-minecraft-launcher
+```
+
+### Passo 2: Instalar Dependências
+Instale todas as dependências do workspace usando `pnpm`:
+```sh
+pnpm install
+```
+
+### Passo 3: Configurar Variáveis de Ambiente
+Crie um arquivo `.env` dentro de `xmcl-electron-app/.env` para configurar o acesso à API do CurseForge:
+```ini
+CURSEFORGE_API_KEY=sua_chave_api_curseforge_aqui
+```
+
+:::warning Aviso de Segurança
+Nunca faça commit do seu arquivo `.env` ou vaze sua `CURSEFORGE_API_KEY` em commits públicos ou Pull Requests.
+:::
+
+---
+
+## 4. Configuração de Editores de Código & Fluxos de Desenvolvimento
+
+O XMCL suporta uma ampla variedade de editores de código modernos. Escolha seu editor abaixo para instruções de configuração, configuração de LSP e execução de tarefas de desenvolvimento:
+
+::: code-group
+```markdown [VS Code]
+### Configuração do Visual Studio Code
+
+O VS Code fornece integração nativa com debuggers integrados.
+
+1. **Extensões Recomendadas**:
+   - Vue Language Features (Volar) (`Vue.volar`)
+   - TypeScript Vue Plugin (`Vue.vscode-typescript-vue-plugin`)
+   - i18n Ally (`lokalise.i18n-ally`)
+2. **Iniciando o Modo Dev**:
+   - Pressione `F5` ou vá em **Executar e Depurar** -> selecione `Electron: Main (launch)`.
+   - O VS Code iniciará automaticamente o servidor de desenvolvimento Vite e anexará o debugger node ao processo principal com suporte completo a breakpoints.
+```
+
+```json [Zed Editor]
+// Configuração do Zed Editor (.zed/tasks.json)
+// O Zed é um editor de alto desempenho acelerado por GPU construído em Rust.
+
+// 1. Instale Extensões:
+// Abra as Extensões do Zed (Cmd+Shift+X / Ctrl+Shift+X) e instale "Vue" e "YAML".
+
+// 2. Adicione Tarefas do Projeto (.zed/tasks.json):
+// Crie um arquivo em `.zed/tasks.json` na pasta raiz:
+[
+  {
+    "label": "Executar XMCL Dev Launcher",
+    "command": "pnpm dev",
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false
+  },
+  {
+    "label": "Executar Linter",
+    "command": "pnpm lint",
+    "use_new_terminal": true
+  },
+  {
+    "label": "Executar Testes",
+    "command": "pnpm test",
+    "use_new_terminal": true
+  }
+]
+
+// 3. Execute Tarefas no Zed:
+// Pressione `Cmd+Shift+P` / `Ctrl+Shift+P` -> digite `task: spawn` -> selecione `Executar XMCL Dev Launcher`.
+```
+
+```lua [Neovim / Vim]
+-- Configuração do Neovim (NVIM)
+-- Configurado via nvim-lspconfig para monorepos Vue 3 + TypeScript.
+
+-- 1. Configuração do LSP (vtsls / volar / yamlls):
+local lspconfig = require('lspconfig')
+
+-- Configuração Vue 3 Volar
+lspconfig.volar.setup({
+  filetypes = { 'typescript', 'javascript', 'javascriptreact', 'typescriptreact', 'vue' },
+  init_options = {
+    vue = {
+      hybridMode = false,
+    },
+  },
+})
+
+-- Servidor de Linguagem YAML
+lspconfig.yamlls.setup({
+  settings = {
+    yaml = { validate = true, completion = true },
+  },
+})
+
+-- 2. Executando o Servidor Dev no Neovim:
+-- Abra o buffer de terminal interno:
+-- :terminal pnpm dev
+-- Ou use toggleterm.nvim (:ToggleTerm)
+
+-- 3. Depurando o Processo Principal (nvim-dap):
+-- Configure o debugger node nvim-dap para anexar à porta 9229 ou iniciar `pnpm dev:main`.
+```
+
+```toml [Helix Editor]
+# Configuração do Helix Editor (.helix/languages.toml)
+
+# Crie `.helix/languages.toml` na raiz do repositório:
+
+[[language]]
+name = "vue"
+auto-format = true
+language-servers = ["volar", "vtsls"]
+
+[[language]]
+name = "typescript"
+auto-format = true
+language-servers = ["vtsls"]
+
+[[language]]
+name = "yaml"
+auto-format = true
+language-servers = ["yaml-language-server"]
+
+# Executando o servidor dev a partir do Helix:
+# Abra o split de terminal ou terminal externo e execute `pnpm dev`.
+```
+
+```markdown [JetBrains / WebStorm]
+### JetBrains IDEs (WebStorm / IntelliJ IDEA)
+
+1. **Instale Plugins**: Certifique-se de que os plugins **Vue.js**, **Tailwind CSS** e **i18n Ally** estão habilitados.
+2. **Crie uma Configuração de Execução**:
+   - Vá em **Executar** -> **Editar Configurações** -> **+** -> **npm**.
+   - Defina **Comando**: `run`
+   - Defina **Scripts**: `dev`
+   - Clique em **Aplicar** e **OK**.
+3. Pressione `Shift+F10` (ou clique no ícone Play) para iniciar o XMCL no modo dev.
+```
+:::
+
+---
+
+## 5. Testes, Linting & Build
+
+### Executando o Linter de Código
+```sh
+pnpm lint
+```
+
+### Executando Testes Unitários
+```sh
+pnpm test
+```
+
+### Criando Bundles de Produção
+```sh
+# 1. Criar bundle da UI frontend
+pnpm build:renderer
+
+# 2. Empacotar distribuição do app Electron
+pnpm build
+```
+
+---
+
+## 6. Padrões de Mensagem de Commit (Conventional Commits)
+
+Este repositório aplica estritamente o padrão [Conventional Commits](https://www.conventionalcommits.org/). Sua mensagem de commit deve seguir este formato:
+
+```
+<tipo>: <descrição curta>
+```
+
+### Tipos de Commit Disponíveis:
+- `feat`: Uma nova funcionalidade para usuários.
+- `fix`: Uma correção de bug para usuários.
+- `docs`: Atualizações de documentação.
+- `style`: Formatação de código (sem alterações de lógica).
+- `refactor`: Refatoração de código sem mudança de funcionalidade.
+- `perf`: Melhorias de performance.
+- `test`: Adição ou atualização de testes.
+- `chore`: Atualizações de scripts de build ou dependências.
+
+**Exemplo**:
+```sh
+git commit -m "feat: adicionar suporte para instalação de modpack NeoForge"
+```

--- a/src/pt/guide/i18n.md
+++ b/src/pt/guide/i18n.md
@@ -1,0 +1,183 @@
+# Primeiros Passos com Localização & Tradução
+
+Obrigado por ajudar a traduzir o X Minecraft Launcher (XMCL)! Este guia cobre tudo o que você precisa saber sobre como configurar seu ambiente de desenvolvimento, navegar pelos arquivos de localização, configurar seu editor de código (**VS Code**, **Zed Editor**, **Neovim**, **JetBrains**), testar suas traduções localmente e enviar um Pull Request.
+
+---
+
+## 1. Pré-requisitos
+
+Antes de começar, certifique-se de ter as seguintes ferramentas instaladas:
+
+- **[Git](https://git-scm.com/)** — Essencial para clonar o repositório e gerenciar branches.
+- **[Node.js](https://nodejs.org/)** (v18+ ou v20+) — Necessário para compilar e executar o XMCL localmente.
+- **[pnpm](https://pnpm.io/)** — O XMCL usa gerenciamento de pacotes com workspace `pnpm`. Ative-o usando o Corepack:
+  ```sh
+  corepack enable
+  ```
+- **Editor de código de sua preferência**:
+  - **VS Code** (com extensão `i18n-ally`)
+  - **Zed Editor** (editor em Rust de alto desempenho)
+  - **Neovim / Vim** (com LSP `yamlls`)
+  - **JetBrains IDEs** (WebStorm / IntelliJ IDEA)
+
+---
+
+## 2. Configuração do Repositório (Fork & Clone)
+
+1. **Fork do Repositório**: Visite o [Repositório GitHub do XMCL](https://github.com/Voxelum/x-minecraft-launcher) e clique em **Fork**.
+2. **Clone com Submódulos**: Você **deve** usar a flag `--recurse-submodules` para buscar os submódulos necessários:
+   ```sh
+   git clone --recurse-submodules https://github.com/seu-usuario/x-minecraft-launcher.git
+   cd x-minecraft-launcher
+   ```
+   *Se esqueceu de adicionar `--recurse-submodules`, inicialize-os manualmente:*
+   ```sh
+   git submodule update --init --recursive
+   ```
+3. **Instale as Dependências**:
+   ```sh
+   pnpm install
+   ```
+
+---
+
+## 3. Arquitetura de Localização no XMCL
+
+O XMCL armazena traduções em arquivos **YAML** em dois módulos principais:
+
+```sh
+x-minecraft-launcher
+ ├─ 📂 xmcl-keystone-ui/locales/       # Strings da UI (botões, abas, diálogos)
+ │   ├─ 📜 en.yaml                     # Inglês (referência canônica)
+ │   ├─ 📜 uk.yaml                     # Ucraniano
+ │   └─ 📜 <código-locale>.yaml
+ └─ 📂 xmcl-electron-app/main/locales/ # Strings do processo principal (bandeja, notificações, erros)
+     ├─ 📜 en.yaml
+     ├─ 📜 uk.yaml
+     └─ 📜 <código-locale>.yaml
+```
+
+---
+
+## 4. Guia de Configuração de Editores de Código
+
+Escolha seu editor preferido abaixo para a melhor experiência de tradução:
+
+::: code-group
+```markdown [VS Code]
+### Configuração do Visual Studio Code
+
+O VS Code fornece ferramentas de UI dedicadas para gerenciamento de chaves de tradução i18n.
+
+1. Instale a extensão **i18n Ally** (`lokalise.i18n-ally`).
+2. Abra a pasta do projeto no VS Code.
+3. Na barra lateral, clique no ícone do **i18n Ally**:
+   - **Aba de Progresso**: Veja as chaves faltantes e a porcentagem de conclusão para todos os idiomas.
+   - **Traduções Inline**: Edite traduções diretamente ao lado dos comentários de código nos arquivos `.vue` e `.ts`.
+4. Abra `en.yaml` e o arquivo do seu idioma alvo (ex: `pt.yaml`) lado a lado (`Ctrl+\` ou `Cmd+\`).
+```
+
+```sh [Zed Editor]
+### Configuração do Zed Editor
+
+O Zed é um editor rápido e acelerado por GPU construído em Rust. Integra-se nativamente com o YAML Language Server (`yaml-lsp`).
+
+1. **Instale Extensões**: Abra as Extensões do Zed (`Cmd+Shift+X` / `Ctrl+Shift+X`) e instale `YAML` e `Vue`.
+2. **Fluxo de Tradução com Painéis Divididos**:
+   - Abra `xmcl-keystone-ui/locales/en.yaml`.
+   - Abra um painel dividido (`Cmd+Shift+E` / `Ctrl+Shift+E` ou clique com botão direito na aba do editor -> Dividir à Direita).
+   - Abra o arquivo do seu idioma alvo (ex: `pt.yaml`).
+3. **Autocompletar LSP**: O Zed fornece completação de chaves instantânea e validação de sintaxe via `yamlls`.
+```
+
+```vim [Neovim (NVIM)]
+" Configuração do Neovim (NVIM)
+
+" Configuração do Neovim usando nvim-lspconfig e yamlls
+
+" 1. Configure yamlls no seu init.lua / lspconfig:
+" require('lspconfig').yamlls.setup({
+"   settings = {
+"     yaml = {
+"       validate = true,
+"       completion = true
+"     }
+"   }
+" })
+
+" 2. Divisão de Buffer Lado a Lado:
+" Abra o arquivo de referência em inglês e divida verticalmente com seu locale alvo:
+:e xmcl-keystone-ui/locales/en.yaml
+:vsplit xmcl-keystone-ui/locales/pt.yaml
+
+" 3. Rolagem Sincronizada:
+" Bloqueie a posição de rolagem entre os buffers de tradução em inglês e alvo:
+:set scrollbind
+
+" 4. Plugins Recomendados:
+" - neovim/nvim-lspconfig & hrsh7th/nvim-cmp (completação YAML)
+" - i18n-ally.nvim ou vim-i18n (resolução de chaves inline)
+```
+
+```markdown [JetBrains / WebStorm]
+### JetBrains IDEs (WebStorm / IntelliJ IDEA)
+
+1. Instale o plugin **i18n Ally** do JetBrains Marketplace.
+2. Abra `en.yaml` e o arquivo `.yaml` do seu locale.
+3. Clique com botão direito na aba do editor -> **Dividir à Direita** para edição lado a lado.
+4. Use `Ctrl+F` / `Cmd+F` para buscar chaves correspondentes ao arquivo de referência em inglês.
+```
+:::
+
+---
+
+## 5. Adicionando um Novo Idioma
+
+Se seu idioma ainda não está registrado no XMCL:
+
+1. **Registre o Código de Idioma em `locales.json`**:
+   Abra `assets/locales.json` e adicione sua entrada de locale:
+   ```json
+   {
+     "zh-CN": "简体中文",
+     "en": "English",
+     "pt": "Português (Brasil)",
+     "fr": "Français"
+   }
+   ```
+2. **Crie Novos Arquivos YAML**:
+   Crie um novo arquivo `.yaml` usando seu código de locale em ambas as pastas de locale:
+   - `xmcl-keystone-ui/locales/pt.yaml`
+   - `xmcl-electron-app/main/locales/pt.yaml`
+3. **Preencha as Traduções**: Copie as chaves de `en.yaml` e traduza os valores para o seu idioma alvo.
+
+---
+
+## 6. Testando Sua Tradução Localmente
+
+1. Certifique-se de que todas as dependências estão instaladas (`pnpm install`).
+2. Execute o ambiente de desenvolvimento:
+   ```sh
+   pnpm dev
+   ```
+   *(Ou no VS Code, pressione `F5` ou vá em **Executar e Depurar** -> selecione `Electron: Main (launch)`).*
+3. Assim que o XMCL abrir, vá em **Configurações ⚙️** -> **Geral** -> **Idioma** e mude para o idioma traduzido para verificar a formatação da UI e a quebra de texto!
+
+---
+
+## 7. Enviando Suas Alterações (Pull Request)
+
+1. Crie uma nova branch git:
+   ```sh
+   git checkout -b i18n/adicionar-traducao-portugues
+   ```
+2. Faça commit das suas alterações:
+   ```sh
+   git add .
+   git commit -m "i18n: adicionar tradução em Português do Brasil"
+   ```
+3. Envie para o seu fork no GitHub:
+   ```sh
+   git push origin i18n/adicionar-traducao-portugues
+   ```
+4. Abra um **Pull Request (PR)** no repositório [x-minecraft-launcher](https://github.com/Voxelum/x-minecraft-launcher)!

--- a/src/pt/guide/install.md
+++ b/src/pt/guide/install.md
@@ -1,0 +1,74 @@
+# Guia de Instalação
+
+O X Minecraft Launcher (XMCL) oferece múltiplos formatos de instalação para Windows, macOS e Linux.
+
+:::tip Guias Úteis
+- 💾 **Precisa mover o launcher ou os dados do jogo para o drive D: ou E:?** Leia o [Guia de Relocação de Drive](./change-drive.md).
+- 🧱 **Quer jogar o Minecraft Bedrock Edition (Windows 10/11)?** Leia o [Guia do Bedrock Edition](./bedrock.md).
+:::
+
+---
+
+## Windows
+
+Várias opções de instalação estão disponíveis para Windows:
+
+### 1. APPX & AppInstaller Online — Recomendado
+- **APPX** é o formato moderno de pacote sandboxed do Windows 10/11. Os apps rodam em um ambiente isolado. Ao desinstalar, o cache e as alterações no registro são removidos de forma limpa.
+- **AppInstaller** baixa e atualiza automaticamente o pacote APPX via canais seguros de entrega da Microsoft com suporte a **atualizações incrementais**.
+
+### 2. Pacote ZIP Portátil
+- Não requer instalação nem privilégios de administrador.
+- Extraia o arquivo em qualquer lugar (ex: `D:\Games\XMCL`) e execute `xmcl.exe` diretamente.
+- Ideal para pendrives ou partições em disco secundário.
+
+### 3. Rodando no Windows 7 / 8 / 8.1 (VxKex Extended Kernel)
+
+:::warning Aviso Importante de Compatibilidade
+O XMCL moderno é construído com **Electron 43 / Chromium 130+**. O Chromium e a Microsoft **encerraram oficialmente todo o suporte para Windows 7, 8 e 8.1**. O launcher **não funcionará nativamente** em versões legadas do Windows por padrão.
+:::
+
+:::details Solução alternativa usando o VxKex Extended Kernel
+Você pode rodar o XMCL no Windows 7 / 8 usando o **VxKex** unofficial extended kernel:
+
+1. Baixe e instale o [VxKex-NEXT](https://github.com/YuZhouRen86/VxKex-NEXT).
+2. Clique com o botão direito em `xmcl.exe` -> **Propriedades** -> aba **VxKex**.
+3. Marque **"Habilitar VxKex NEXT para este programa"** e **"Reportar outras versões do Windows"**, depois aplique.
+
+**O que funciona e o que não funciona no Windows 7/8:**
+- ✅ **Singleplayer (Java Edition)** — Funciona normalmente com um runtime Java adequado (Java 8 / 17 / 21).
+- ❌ **Multijogador P2P WebRTC** — Não suportado (requer APIs de rede do Windows 10+).
+- ❌ **Bedrock Edition (UWP)** — Não suportado (requer o framework UWP do Windows 10/11).
+:::
+
+---
+
+## macOS
+
+### Pacote DMG
+1. Baixe e abra o arquivo `.dmg`.
+2. Arraste **X Minecraft Launcher.app** para a pasta **Aplicativos**.
+
+:::warning Liberação do Gatekeeper
+Para remover o aviso de aplicativo não assinado no macOS, execute este comando no Terminal:
+
+```sh
+sudo xattr -c /Applications/X\ Minecraft\ Launcher.app
+```
+:::
+
+---
+
+## Linux
+
+### AppImage
+- Binário universal para distribuições Linux (Ubuntu, Fedora, Arch, etc.).
+- Marque como executável: `chmod +x XMCL.AppImage` e execute.
+
+---
+
+## Seleção do Diretório de Dados do Jogo
+
+Durante a configuração inicial, o XMCL solicita um **Diretório de Dados do Jogo**.
+- Recomenda-se escolher uma pasta dedicada (ex: `D:\XMCL-Data`).
+- Para mais detalhes, veja o [Guia de Gerenciamento de Dados](./manage.md) e o [Guia de Relocação de Drive](./change-drive.md).

--- a/src/pt/guide/manage.md
+++ b/src/pt/guide/manage.md
@@ -1,0 +1,85 @@
+# Gerenciamento de Dados e Armazenamento
+
+A arquitetura de dados do X Minecraft Launcher (XMCL) é dividida em dois componentes distintos:
+
+1. **Configurações do Sistema & Banco de Dados do XMCL** (configurações, contas, cache do marketplace).
+2. **Dados do Jogo Minecraft** (versões, instâncias, mods, mundos, assets).
+
+:::tip Relocar Armazenamento para Outro Drive
+Sem espaço no drive `C:`? Você pode facilmente mover todo o Diretório de Dados do Jogo para o drive `D:` ou `E:`. Veja o [Guia de Relocação de Drive](./change-drive.md).
+:::
+
+---
+
+## 1. Cache do Sistema & Banco de Dados do XMCL
+
+:::tip 💡 Forma Mais Fácil de Abrir o Diretório de Dados
+Você não precisa procurar manualmente em pastas ocultas do sistema! Dentro do launcher, vá em **Configurações ⚙️** -> **Configurações Globais** -> **Armazenamento** e clique em **"Abrir Diretório de Dados"**. O XMCL abrirá automaticamente a pasta exata no Explorador de Arquivos do Windows!
+:::
+
+### Caminhos Exatos das Pastas do Sistema por Tipo de Instalação:
+
+Se estiver navegando manualmente no Explorador de Arquivos (pressione `Win + R` e cole o caminho correspondente):
+
+#### 🔹 Opção 1: Instalação AppX / AppInstaller / WinGet (Mais Comum)
+Os pacotes AppX rodam em um ambiente sandboxed no Windows 10/11. Seus dados são armazenados **NÃO no `Roaming` padrão do AppData**, mas dentro do sandbox do pacote Windows:
+```cmd
+%LocalAppData%\Packages\XMCL_68mcaawk44tpj\LocalCache\Roaming\xmcl
+```
+*(Caminho completo: `C:\Users\<Seu_Usuário>\AppData\Local\Packages\XMCL_68mcaawk44tpj\LocalCache\Roaming\xmcl`)*
+
+#### 🔹 Opção 2: Instalação EXE Padrão
+```cmd
+%AppData%\xmcl
+```
+*(Caminho completo: `C:\Users\<Seu_Usuário>\AppData\Roaming\xmcl`)*
+
+#### 🔹 Opção 3: Pacote ZIP Portátil
+Para o pacote ZIP portátil, os dados são armazenados diretamente na mesma pasta onde você extraiu o `XMCL` (junto com o `xmcl.exe`), ou no Diretório de Dados do Jogo selecionado.
+
+#### 🔹 macOS & Linux:
+- **macOS**: `~/Library/Application Support/xmcl`
+- **Linux**: `~/.config/xmcl`
+
+---
+
+### Arquivos de Configuração Principais:
+- **`user.json`** — Perfis de conta (Microsoft, Yggdrasil, Offline), tokens e links de skin.
+- **`settings.json`** — Configuração global do launcher (caminho dos dados, idioma, tema, proxy, nós de download).
+- **`instances.json`** — Registro de todas as instâncias criadas e a última instância selecionada.
+- **`java.json`** — Cache das instalações de runtime Java detectadas.
+- **`resources-v2/`** — Banco de dados LevelDB contendo metadados indexados de mods, pacotes de recursos e shaders.
+- **`logs/`** — Logs de execução do launcher (`main.log`, `renderer.log`).
+
+---
+
+## 2. Diretório de Dados do Jogo Minecraft
+
+Todos os arquivos pesados do jogo são armazenados dentro do **Diretório de Dados do Jogo**.
+
+### Estrutura de Diretórios:
+
+```sh
+📂 Diretório de Dados do Jogo
+ ├─ 📂 instances/        # Instâncias individuais do Minecraft
+ │   ├─ 📂 Fabric-1.20/  # Pasta de instância específica
+ │   │   ├─ 📂 saves/        # Arquivos de mundo para esta instância
+ │   │   ├─ 📂 options.txt   # Configurações do jogo para esta instância
+ │   │   ├─ 📂 screenshots/  # Capturas de tela
+ │   │   └─ 📂 mods/         # Links físicos/simbólicos para mods compartilhados
+ ├─ 📂 mods/             # Pool global de mods compartilhados
+ ├─ 📂 resourcepacks/    # Pool de pacotes de recursos compartilhados
+ ├─ 📂 shaderpacks/      # Pool de pacotes de shaders compartilhados
+ ├─ 📂 versions/         # Versões do Minecraft baixadas (JAR, JSON)
+ ├─ 📂 assets/           # Assets e texturas do jogo Minecraft
+ ├─ 📂 libraries/        # Bibliotecas Java compartilhadas
+ └─ 📂 modpacks/         # Modpacks salvos e exportados
+```
+
+---
+
+## 3. Como o XMCL Economiza Espaço em Disco (Links Físicos)
+
+1. Cada arquivo de mod é baixado **apenas uma vez** no pool global `mods/`.
+2. Adicionar um mod a múltiplas instâncias cria um **link físico** leve na pasta dessa instância.
+3. **Resultado**: 10 instâncias usando mods idênticos não ocupam espaço extra além de uma única instância!

--- a/src/pt/guide/microsoft-login-issues.md
+++ b/src/pt/guide/microsoft-login-issues.md
@@ -1,0 +1,147 @@
+# Problemas de Login Microsoft, Modo Demo & Licenciamento
+
+Este guia explica como fazer login na sua conta Microsoft no XMCL, o que fazer se você encontrar o erro **"failed to exchange Xbox token"**, por que o Minecraft pode iniciar no **Modo Demo**, e como jogar sem uma licença paga usando logins alternativos.
+
+---
+
+## 🔑 1. Fazendo Login com uma Conta Microsoft
+
+Para entrar e jogar com sua licença oficial do Minecraft, siga estes passos:
+
+1. Clique no seu perfil/avatar (ou **"Gerenciar Conta"**) no canto superior direito para abrir o Gerenciador de Contas:
+
+   <video src="/guidephoto/My%20stuff.mp4" controls autoplay loop muted playsinline style="border-radius: 8px; max-width: 100%; border: 1px solid var(--vp-c-divider); margin: 12px 0;"></video>
+
+2. Clique em **"Adicionar Conta"**, escolha **Microsoft**, e prossiga com o login:
+
+   <video src="/guidephoto/add%20account.mp4" controls autoplay loop muted playsinline style="border-radius: 8px; max-width: 100%; border: 1px solid var(--vp-c-divider); margin: 12px 0;"></video>
+
+> 💡 **Entrar via Código de Dispositivo:**  
+> Se não quiser digitar sua senha dentro do launcher, marque **"Login por Código de Dispositivo"**. O XMCL mostrará um código; basta visitar `microsoft.com/link` no seu navegador, digitar o código e confirmar o login.
+
+---
+
+## 🔍 2. Como Funciona a Autenticação Microsoft
+
+Ao fazer login, o launcher deve verificar sua identidade em três camadas de autenticação separadas:
+
+<div style="display: flex; flex-direction: column; gap: 16px; margin: 24px 0; padding: 20px; border-radius: 12px; background: var(--vp-c-bg-soft); border: 1px solid var(--vp-c-divider);">
+  <div style="display: flex; align-items: center; gap: 8px;">
+    <span style="font-weight: 600; font-size: 1.1rem; color: var(--vp-c-text-1);">🔑 Handshake de Autenticação:</span>
+  </div>
+  <div style="display: flex; flex-wrap: wrap; gap: 12px; align-items: center; justify-content: center; margin: 10px 0;">
+    <div style="background: rgba(59, 130, 246, 0.1); border: 1px solid rgba(59, 130, 246, 0.3); padding: 12px; border-radius: 8px; text-align: center; min-width: 150px;">
+      <div style="font-weight: 600; color: #3b82f6; font-size: 0.85rem;">PASSO 1</div>
+      <div style="font-size: 0.9rem; margin-top: 4px; color: var(--vp-c-text-1);">Login Microsoft</div>
+      <div style="font-size: 0.75rem; color: var(--vp-c-text-3);">Verifica a Senha</div>
+    </div>
+    <div style="color: var(--vp-c-text-3); font-weight: bold;">➔</div>
+    <div style="background: rgba(16, 185, 129, 0.1); border: 1px solid rgba(16, 185, 129, 0.3); padding: 12px; border-radius: 8px; text-align: center; min-width: 150px;">
+      <div style="font-weight: 600; color: #10b981; font-size: 0.85rem;">PASSO 2</div>
+      <div style="font-size: 0.9rem; margin-top: 4px; color: var(--vp-c-text-1);">Serviços Xbox Live</div>
+      <div style="font-size: 0.75rem; color: var(--vp-c-text-3);">Obtém o Gamertag</div>
+    </div>
+    <div style="color: var(--vp-c-text-3); font-weight: bold; color: #ef4444;">➔ ❌ Falha Aqui</div>
+    <div style="background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); padding: 12px; border-radius: 8px; text-align: center; min-width: 150px;">
+      <div style="font-weight: 600; color: #ef4444; font-size: 0.85rem;">PASSO 3 (Exchange)</div>
+      <div style="font-size: 0.9rem; margin-top: 4px; color: var(--vp-c-text-1);">Token do Minecraft</div>
+      <div style="font-size: 0.75rem; color: var(--vp-c-text-3);">Verifica a Licença</div>
+    </div>
+  </div>
+  <p style="font-size: 0.9rem; color: var(--vp-c-text-2); margin: 0; text-align: center; line-height: 1.6;">
+    Se o Passo 3 falhar, o login será rejeitado com <strong>"failed to exchange Xbox token"</strong>, ou o jogo iniciará no <strong>Modo Demo</strong>. Ambos os sintomas significam que os servidores de autenticação da Mojang não conseguiram verificar uma licença válida do Minecraft na sua conta Microsoft.
+  </p>
+</div>
+
+---
+
+## 🛠 3. Solucionando Problemas de Login Microsoft & Modo Demo
+
+Se você possui o jogo mas encontra falhas de login ou a tela de Demo:
+
+### Causa A: Sem Licença do Minecraft nesta Conta Microsoft
+
+<div style="display: flex; gap: 16px; align-items: flex-start; padding: 20px; border-radius: 12px; background: rgba(239, 68, 68, 0.05); border: 1px solid rgba(239, 68, 68, 0.2); margin: 20px 0;">
+  <div style="flex-shrink: 0; background: rgba(239, 68, 68, 0.1); padding: 8px; border-radius: 8px; display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; color: #ef4444; font-weight: bold; font-size: 1.25rem;">
+    🎮
+  </div>
+  <div>
+    <h4 style="margin-top: 0 !important; font-size: 1.1rem; font-weight: 600; color: var(--vp-c-text-1);">Os servidores da Mojang não encontraram o jogo comprado</h4>
+    <p style="color: var(--vp-c-text-2); font-size: 0.95rem; line-height: 1.5; margin-bottom: 0;">Este é o motivo mais comum. Você fez login com sucesso, mas a Mojang informa que esta conta específica não possui o Minecraft Java Edition.</p>
+  </div>
+</div>
+
+#### Como corrigir:
+* **Verifique a Compra:** Faça login em [Minecraft.net](https://www.minecraft.net/) usando sua conta Microsoft e verifique se você vê a opção de download em vez de uma solicitação de compra.
+* **Verifique o Status do Game Pass:** Se jogar via **Xbox Game Pass**, certifique-se de que sua assinatura está ativa e que você está fazendo login com a conta Microsoft exata associada à assinatura ativa.
+* **Verifique o Email:** Certifique-se de não estar fazendo login com uma conta Microsoft diferente (como um email escolar ou corporativo) em vez da conta pessoal que possui a compra.
+
+---
+
+### Causa B: Perfil Xbox Live Ausente
+
+<div style="display: flex; gap: 16px; align-items: flex-start; padding: 20px; border-radius: 12px; background: rgba(245, 158, 11, 0.05); border: 1px solid rgba(245, 158, 11, 0.2); margin: 20px 0;">
+  <div style="flex-shrink: 0; background: rgba(245, 158, 11, 0.1); padding: 8px; border-radius: 8px; display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; color: #f59e0b; font-weight: bold; font-size: 1.25rem;">
+    👤
+  </div>
+  <div>
+    <h4 style="margin-top: 0 !important; font-size: 1.1rem; font-weight: 600; color: var(--vp-c-text-1);">Conta Microsoft não ativada no Xbox Live</h4>
+    <p style="color: var(--vp-c-text-2); font-size: 0.95rem; line-height: 1.5; margin-bottom: 0;">Você criou uma conta Microsoft mas nunca inicializou os serviços do Xbox Live. Os servidores de login não conseguem gerar um token de acesso porque a conta não tem um Gamertag único.</p>
+  </div>
+</div>
+
+#### Como corrigir:
+1. Acesse o site oficial [Xbox.com](https://www.xbox.com/).
+2. Clique em **Entrar** no canto superior direito.
+3. Se solicitado a criar um perfil Xbox, **aceite o contrato e configure um Gamertag** (apelido único).
+4. Aguarde 1-2 minutos para os servidores sincronizarem, depois abra o XMCL e tente fazer login novamente.
+
+---
+
+### Causa C: Bloqueios de Rede e Restrições de Roteamento do Provedor
+
+<div style="display: flex; gap: 16px; align-items: flex-start; padding: 20px; border-radius: 12px; background: rgba(139, 92, 246, 0.05); border: 1px solid rgba(139, 92, 246, 0.2); margin: 20px 0;">
+  <div style="flex-shrink: 0; background: rgba(139, 92, 246, 0.1); padding: 8px; border-radius: 8px; display: flex; align-items: center; justify-content: center; width: 44px; height: 44px; color: #8b5cf6; font-weight: bold; font-size: 1.25rem;">
+    🌐
+  </div>
+  <div>
+    <h4 style="margin-top: 0 !important; font-size: 1.1rem; font-weight: 600; color: var(--vp-c-text-1);">Conexão bloqueada com servidores Mojang ou Microsoft</h4>
+    <p style="color: var(--vp-c-text-2); font-size: 0.95rem; line-height: 1.5; margin-bottom: 0;">Devido a bloqueios regionais do provedor, firewalls locais ou configurações de DNS corrompidas, seu PC não consegue estabelecer conexão com `api.minecraftservices.com` ou servidores de login do Xbox Live.</p>
+  </div>
+</div>
+
+#### Como corrigir:
+* **Use uma VPN:** Conecte-se a uma VPN estável antes de tentar fazer login. Isso contorna o throttling do provedor e caminhos de roteamento bloqueados.
+* **Configure o Proxy dentro do XMCL:**
+  1. Abra as **Configurações** (ícone de engrenagem na barra lateral esquerda).
+  2. Navegue até **Configurações de Rede**.
+  3. Insira o endereço do seu servidor proxy ativo (protocolos HTTP, HTTPS e SOCKS5 são suportados).
+* **Redefina seu arquivo hosts:** Certifique-se de que não há regras redirecionando `mojang.com` ou `minecraftservices.com` no arquivo hosts do sistema.
+
+---
+
+## 🆓 4. Jogando Sem Licença (Logins Alternativos)
+
+Se você não possui uma cópia licenciada do Minecraft, pode jogar usando sistemas alternativos de login. O XMCL inclui um **Modo Desenvolvedor** para permitir jogo offline e serviços de autenticação de terceiros.
+
+### Como Ativar o Modo Desenvolvedor:
+1. Vá em **Configurações** (ícone de engrenagem na barra lateral esquerda).
+2. Encontre a opção **"Modo Desenvolvedor"** e ative-a:
+
+   ![Ativando o Modo Desenvolvedor](/guidephoto/developer-mode.png)
+
+Após ativar, você verá opções adicionais de autenticação no Gerenciador de Contas ao adicionar uma conta:
+
+### 🟢 Modo Offline
+- Jogue **localmente** sem se conectar aos servidores da Mojang.
+- Simplesmente escolha qualquer nome de usuário e comece a jogar em single-player ou mundos multijogador locais.
+
+### 🟡 Littleskin
+- Um servidor de autenticação e skin gratuito da comunidade.
+- Permite usar skins personalizadas sem uma licença paga do Minecraft.
+- Website: [https://littleskin.cn](https://littleskin.cn)
+
+### 🔵 Ely.by
+- Um banco de dados popular de skins e contas de terceiros.
+- Suporta skins personalizadas, capas e é compatível com muitos servidores da comunidade.
+- Website: [https://ely.by](https://ely.by)

--- a/src/pt/guide/troubleshooting.md
+++ b/src/pt/guide/troubleshooting.md
@@ -1,0 +1,227 @@
+# Solução de Problemas de Instalação & Inicialização
+
+Se você encontrar problemas ao instalar o Minecraft, mod loaders (Forge/Fabric/NeoForge/Quilt), mods, modpacks ou shaders, ou se o jogo falhar ao iniciar, este guia ajudará você a resolver passo a passo.
+
+---
+
+## 🌐 1. Download Falha ou Trava (Problemas de Rede)
+
+### Sintomas
+* O download do Minecraft, assets, bibliotecas ou Forge/Fabric fica parado em `0%`.
+* O launcher exibe erros de timeout ou conexão (`CONNECTION_TIMED_OUT`, `NAME_NOT_RESOLVED`, `HTTP_STATUS 504`).
+
+### Soluções
+
+:::tip Tente um Mirror de Download
+Se os servidores oficiais da Mojang ou Forge estiverem lentos ou bloqueados pelo seu provedor de internet, você pode mudar para um mirror:
+1. Clique em **Configurações** (ícone de engrenagem) na barra lateral esquerda.
+2. Role até a seção **Configurações de Rede**.
+3. Encontre a configuração **Fonte de Download / Mirror**.
+4. Mude de **Padrão** para **BMCLAPI** ou **MCBBS** (mirrors altamente confiáveis que copiam os assets oficiais).
+:::
+
+:::info Configure um Proxy
+Se você está atrás de um firewall ou em uma região com acesso restrito à internet, configure um proxy no launcher:
+1. Em **Configurações** -> **Configurações de Rede**, encontre as opções de proxy.
+2. Configure seu endereço de proxy SOCKS5 ou HTTP.
+3. Teste a conexão.
+:::
+
+---
+
+## 📦 2. Download de Mod / Modpack Falha (Restrição da API do CurseForge)
+
+### Sintomas
+* Ao baixar um modpack ou mod do CurseForge, alguns mods falham ao baixar e exibem um ícone de aviso.
+* Uma mensagem avisa sobre "downloads de terceiros restritos".
+
+### Causa
+Alguns autores de mods no CurseForge desativam os downloads via API de launchers de terceiros para forçar jogadores a visitar sua página.
+
+### Solução
+O XMCL lida com isso permitindo que você baixe manualmente os arquivos ausentes:
+1. Veja os detalhes da tarefa de download no gerenciador de tarefas do launcher (canto superior direito).
+2. Clique no link fornecido ao lado do mod com falha para abrir sua página de download no navegador.
+3. Baixe o arquivo `.jar` manualmente pelo navegador.
+4. **Arraste e solte** o arquivo `.jar` baixado diretamente na janela do launcher (ou coloque na pasta `mods/` da instância).
+5. O XMCL o identificará automaticamente e retomará/completará a instalação.
+
+---
+
+## 🔄 3. Loop Infinito de Corrupção de Arquivo (Incompatibilidade de Checksum)
+
+### Sintomas
+* O launcher fica baixando continuamente uma biblioteca ou arquivo de asset, dizendo que está corrompido.
+* O jogo falha ao iniciar porque a validação falha repetidamente.
+
+### Causa
+Um download de arquivo foi interrompido e um arquivo parcial corrompido está travado no seu cache, impedindo o launcher de substituí-lo corretamente.
+
+### Solução
+1. Encontre o caminho do arquivo corrompido mostrado nos diagnósticos ou logs do launcher (ex: `libraries/org/lwjgl/...`).
+2. Abra a pasta de dados da instância (clique no ícone de pasta no canto superior direito do painel da instância).
+3. Navegue até o caminho especificado no erro e **exclua a pasta que contém** a biblioteca/asset corrompida.
+4. Clique em **Reparar** ou reinicie o processo de inicialização. O launcher baixará uma cópia nova e limpa.
+
+---
+
+## ☕ 4. Jogo Crasha Instantaneamente (Versão Java Incompatível)
+
+### Sintomas
+* O jogo inicia mas crasha imediatamente com código de saída `1` ou `-1`.
+* O log diz `UnsupportedClassVersionError` ou "Java not found".
+
+### Causa
+Cada versão do Minecraft requer uma versão específica de Java (JDK). Usar a versão errada fará o jogo crashar.
+
+### Solução
+O XMCL tem um gerenciador de Java automático que baixa as versões corretas do JDK para você.
+
+:::warning Matriz de Compatibilidade Java
+Certifique-se de que sua instância está usando a versão correta de Java:
+* **Minecraft 1.12.2 e mais antigos:** Java 8
+* **Minecraft 1.16 - 1.17:** Java 16 / 17
+* **Minecraft 1.18 - 1.20.4:** Java 17
+* **Minecraft 1.20.5+:** Java 21
+:::
+
+#### Como gerenciar o Java no XMCL:
+1. Vá nas configurações da instância (ícone de engrenagem ao lado do botão Jogar).
+2. Olhe na seção **Java**.
+3. Clique na caixa de seleção. O XMCL listará todas as versões de Java detectadas no seu sistema e destacará as compatíveis.
+4. Se você não tem a versão correta de Java, clique em **Instalar Java** para deixar o launcher baixar a versão ideal automaticamente.
+
+---
+
+## 📑 5. Launcher Não Abre ou Tela Preta
+
+### Sintomas
+* Clicar duas vezes no launcher não faz nada.
+* A janela do launcher abre mas permanece completamente preta.
+
+### Solução
+Você pode encontrar os arquivos de log para ver o que está causando o crash:
+1. Vá ao diretório de dados do aplicativo local:
+   * **Windows:** `%appdata%\xmcl`
+   * **macOS:** `~/Library/Application Support/xmcl`
+   * **Linux:** `~/.config/xmcl`
+2. Abra a pasta `logs` e procure o arquivo `main.log` mais recente.
+
+---
+
+## 🔍 6. Mod Está no Site do CurseForge mas Não Aparece na Busca do Launcher
+
+### Sintomas
+* Você busca um mod dentro do launcher, mas ele diz "Nenhum resultado encontrado", mesmo sendo visível no site oficial do CurseForge.
+
+### Causa
+O CurseForge permite que autores de mods **desativem o acesso de API de terceiros** para seus mods. Quando desativado, a API do CurseForge (que o XMCL usa para buscar mods) é proibida de retornar o mod nos resultados de busca.
+
+### Solução
+1. Abra seu navegador e acesse a página do mod no [CurseForge](https://www.curseforge.com/minecraft/search).
+2. Clique em **Download** para salvar o arquivo `.jar` no seu computador.
+3. Abra o XMCL e selecione sua instância ativa.
+4. **Arraste e solte** o arquivo `.jar` baixado diretamente na janela do launcher. O XMCL o instalará automaticamente na pasta `mods` da instância selecionada.
+
+---
+
+## 📦 7. Modpacks Importados "Somem" ou Parecem Vazios
+
+### Sintomas
+* Você arrasta e solta um arquivo `.zip` ou `.mrpack` de modpack no launcher, mas não consegue encontrá-lo no seu perfil atual, ou a lista de mods aparece vazia.
+
+### Causa
+1. **Criação de Nova Instância**: O XMCL não mescla modpacks no seu perfil ativo. Em vez disso, cria uma **nova Instância** (perfil) completamente para aquele modpack.
+2. **Tarefas de Download em Segundo Plano**: Os arquivos de modpack não contêm os arquivos `.jar` reais dos mods para economizar espaço (contêm apenas metadados). Após importar, o XMCL inicia uma tarefa em segundo plano para baixar todos os mods. Até que essa tarefa termine, a lista de mods pode parecer vazia.
+
+### Solução
+1. **Mude de Instância**: Clique no menu da barra lateral ou seletor de perfil para ver todas as instâncias. Procure por uma nova instância com o nome do modpack importado e selecione-a.
+2. **Verifique o Gerenciador de Tarefas**: Clique no ícone de Tarefas (canto superior direito do launcher) para verificar se a tarefa de download do modpack ainda está em execução. Aguarde o download ser concluído antes de iniciar o jogo.
+
+---
+
+## 📋 8. Gerar um Relatório de Diagnóstico (Primeiro Passo Recomendado)
+
+Antes de procurar arquivos de log manualmente, recomendamos gerar um **Relatório de Diagnóstico** dentro do launcher. Isso compila todos os logs do launcher, logs do jogo e informações do ambiente do sistema em um único pacote, permitindo que a comunidade ou desenvolvedores te ajudem muito mais rápido.
+
+### Como Gerar um Relatório:
+1. Clique no menu **Ajuda & Feedback** no cabeçalho do launcher.
+2. Clique em **Gerar Relatório** para empacotar os diagnósticos e logs do launcher.
+
+   <img src="/guidephoto/Generate%20Report.gif" alt="Gerar Relatório" style="border-radius: 8px; max-width: 100%; border: 1px solid var(--vp-c-divider); margin: 12px 0;">
+
+---
+
+## 📑 9. Como Analisar Logs do Launcher & do Jogo
+
+Se preferir encontrar os logs manualmente, eles mostrarão exatamente o que está acontecendo. Veja como localizá-los e entender cenários comuns de crash.
+
+### 🔍 Como Encontrar os Logs
+
+Dependendo se é um erro do launcher ou um crash do jogo, você precisará verificar logs diferentes:
+
+#### A. Logs do Launcher (`main.log`)
+Para crashes do launcher, falhas de download, erros de rede ou problemas de login:
+- **Windows:** Pressione `Win + R`, digite `%appdata%\xmcl\logs` e pressione Enter.
+- **macOS:** Navegue até `~/Library/Application Support/xmcl/logs`.
+- **Linux:** Vá para `~/.config/xmcl/logs`.
+- Encontre o arquivo mais recente chamado `main.log`.
+
+#### B. Logs do Jogo (`latest.log` & Relatórios de Crash)
+Para conflitos de mods, crashes do Minecraft, problemas de desempenho ou erros de Java:
+- Abra o card da instância no launcher.
+- Clique no ícone de **Pasta** no canto superior direito do painel da instância para abrir seu diretório.
+- Vá para a pasta `logs` e abra `latest.log`.
+- Se o jogo crashou e fechou, vá para a pasta `crash-reports` e procure o arquivo `.txt` mais recente (nomeado como `crash-AAAA-MM-DD_HH.MM.SS-client.txt`).
+
+---
+
+### 🛠 Como Analisar Logs & Corrigir Erros Comuns
+
+Abra o arquivo de log em qualquer editor de texto (como o Bloco de Notas) e procure pelos seguintes erros (você pode usar `Ctrl + F` para buscar):
+
+#### 🔴 Caso 1: Erro de Memória Insuficiente
+- **O que procurar:** `java.lang.OutOfMemoryError: Java heap space` ou `Exit code: -805306369`.
+- **Explicação:** Você não alocou RAM suficiente para o jogo carregar todos os mods.
+- **Como corrigir:**
+  1. Abra as configurações da instância (ícone de engrenagem ao lado do botão Jogar).
+  2. Role para baixo até a seção **Java**.
+  3. Aumente a **Memória Mínima** e a **Memória Máxima** (ex: defina Memória Máxima para `4096` ou `6144` MB).
+
+#### 🔴 Caso 2: Incompatibilidade de Mod ou Dependências Ausentes
+- **O que procurar:** `Mixin transformation failed`, `DependencyResolutionException`, ou linhas como `Requires mod 'fabric' (version X or later), but only version Y is installed`.
+- **Explicação:** Um dos seus mods requer outro mod (dependência) que está ausente, ou dois mods são incompatíveis entre si.
+- **Como corrigir:** Leia a linha de erro cuidadosamente. Geralmente nomeia o mod ausente. Baixe e coloque o arquivo jar do mod ausente na pasta `mods`, ou atualize o mod conflitante para uma versão compatível.
+
+#### 🔴 Caso 3: Versão Java Incompatível
+- **O que procurar:** `java.lang.UnsupportedClassVersionError: ... has been compiled by a more recent version of the Java Runtime`.
+- **Explicação:** Você está executando uma versão do Minecraft ou modpack com uma versão Java incompatível (ex: usando Java 8 para Minecraft 1.20).
+- **Como corrigir:** Abra as configurações da instância, vá para a seção **Java**, e clique em **Instalar Java** para baixar a versão Java recomendada para aquela versão específica do Minecraft.
+
+#### 🔴 Caso 4: Crash do Driver da Placa de Vídeo
+- **O que procurar:** `GLFW error 65542: WGL: The driver does not seem to support OpenGL` ou `Pixel format not accelerated`.
+- **Explicação:** Os drivers da sua placa de vídeo estão desatualizados, ausentes, ou o jogo está rodando na GPU integrada do CPU em vez da GPU dedicada.
+- **Como corrigir:** Atualize os drivers gráficos para a versão mais recente no site oficial do fabricante (NVIDIA, AMD ou Intel). Para notebooks, certifique-se de que o launcher está rodando na GPU de alto desempenho nas configurações do sistema.
+
+---
+
+### ❓ O Que Fazer se Não Conseguir Entender os Logs?
+
+Se você olhou pelos logs/relatórios e ainda não sabe o que está causando o crash, não se preocupe! A comunidade do XMCL está aqui para ajudar em várias plataformas:
+
+#### 1. Entre no Nosso Servidor Discord Oficial
+- Obtenha ajuda imediata de desenvolvedores e jogadores experientes.
+- Entre em: **[Link do Servidor Discord](https://discord.gg/W5XVwYY7GQ)**
+- **Como perguntar:** Vá para o canal **#feedback-and-idea** e faça upload do seu relatório de diagnóstico ou arquivo de log de crash.
+- Veja esta ilustração do nosso canal de feedback:
+  
+  <img src="/guidephoto/Discord-feedback.gif" style="border-radius: 8px; max-width: 100%; border: 1px solid var(--vp-c-divider); margin: 12px 0;" />
+
+#### 2. Pergunte no Reddit
+- Você pode postar seus problemas e perguntar à comunidade no nosso subreddit:
+- Visite: **[Subreddit r/XMCL](https://www.reddit.com/r/XMCL/)**
+
+#### 3. Abra uma Issue no GitHub
+- Se você acredita ter encontrado um bug no próprio launcher, pode registrar um relatório de bug.
+- Envie aqui: **[Issues do XMCL no GitHub](https://github.com/Voxelum/x-minecraft-launcher/issues)**
+- Cole o conteúdo do seu relatório ou logs dentro da descrição da issue para que os desenvolvedores possam depurá-la.

--- a/src/pt/index.md
+++ b/src/pt/index.md
@@ -1,0 +1,5 @@
+---
+layout: welcome-modern
+description: Potencialize sua experiência no Minecraft com um launcher moderno
+title: X Minecraft Launcher - Um launcher de Minecraft completo
+---

--- a/src/pt/linux-minecraft-launcher.md
+++ b/src/pt/linux-minecraft-launcher.md
@@ -1,0 +1,6 @@
+---
+title: Launcher de Minecraft para Linux | XMCL
+description: O XMCL é um launcher de Minecraft polido para Linux com suporte nativo a DEB, RPM, AppImage, tar.xz, Flathub e Steam Deck.
+---
+
+<scene-landing kind="linux" />

--- a/src/pt/log-viewer.md
+++ b/src/pt/log-viewer.md
@@ -1,0 +1,6 @@
+---
+title: Visualizador de Logs do XMCL | X Minecraft Launcher
+description: Leia os logs de suporte do XMCL localmente no seu navegador.
+---
+
+<LogViewer />

--- a/src/pt/modpack-creator.md
+++ b/src/pt/modpack-creator.md
@@ -1,0 +1,6 @@
+---
+title: Ferramentas para Criadores de Modpacks Minecraft | XMCL
+description: Crie, teste, diagnostique, atualize e exporte modpacks Minecraft para Modrinth e CurseForge com o XMCL.
+---
+
+<scene-landing kind="creators" />

--- a/src/pt/prebuilds.md
+++ b/src/pt/prebuilds.md
@@ -1,0 +1,5 @@
+---
+layout: prebuilds
+description: Baixe os Prebuilds do XMCL se quiser as funcionalidades mais recentes e não puder esperar pelo próximo lançamento!
+title: X Minecraft Launcher - Baixar Prebuilds do XMCL
+---

--- a/src/pt/protocol/p2p.md
+++ b/src/pt/protocol/p2p.md
@@ -1,0 +1,494 @@
+# Protocolo Online do Minecraft Baseado em WebRTC
+
+Este artigo descreve uma implementação de launcher para Minecraft que permite jogar entre redes locais diferentes através do WebRTC.
+
+## O que é WebRTC? Por que usá-lo?
+
+WebRTC é uma tecnologia de comunicação em tempo real ponto a ponto. Para citar o [MDN](https://developer.mozilla.org/pt-BR/docs/Web/API/WebRTC_API):
+
+> WebRTC (Web Real-Time Communications) é uma tecnologia de código aberto que permite comunicação em tempo real através de conexões ponto a ponto.
+
+O WebRTC foi originalmente projetado para streaming de áudio e vídeo em tempo real entre navegadores, mas isso não limita seu uso em um launcher.
+
+Então por que escolher WebRTC em vez de outras tecnologias? A tabela a seguir compara três formas de implementar jogo online:
+
+|                     | WebRTC             | Hole Punching Personalizado (Protocolo Customizado) | Hiper e outros softwares de terceiros |
+| ------------------- | ------------------ | --------------------------------------------------- | ------------------------------------- |
+| Personalização      | Alta               | Máxima                                              | -                                     |
+| Dificuldade de Implementação | Baixa   | Alta                                                | Mínima                                |
+| Facilidade de Uso para Usuários | Depende da Implementação | Depende da Implementação | Requer Permissões de Admin, custo envolvido |
+
+### Personalização
+
+WebRTC e hole punching personalizado oferecem aos desenvolvedores o máximo controle. Com hole punching personalizado, o protocolo é completamente livre de restrições de implementação, pois tudo precisa ser implementado do zero.
+
+Em contraste, a menos que SDKs sejam fornecidos, estender outras funções com base em serviços como o Hiper pode ser difícil.
+
+O WebRTC apenas lida com o estabelecimento de conexão entre usuários, enquanto os desenvolvedores têm controle total sobre quais dados transferir, quando transferir e como lidar com os dados.
+
+### Dificuldade de Implementação
+
+O hole punching personalizado é o mais difícil em termos de dificuldade de engenharia. Como o WebRTC e o hole punching personalizado compartilham princípios similares, o hole punching personalizado exige que o desenvolvedor implemente a funcionalidade do WebRTC do zero.
+
+No processo, os desenvolvedores podem enfrentar vários bugs, e o escopo que consideram pode não ser tão abrangente quanto o dos desenvolvedores do protocolo WebRTC.
+
+Usar WebRTC é como estar sobre os ombros de gigantes; os desenvolvedores não precisam lidar diretamente com as várias situações complexas encontradas ao estabelecer conexões, mas simplesmente usar as interfaces encapsuladas pelo WebRTC. Assim, a dificuldade de implementação do WebRTC é muito menor do que escrever hole punching personalizado completamente do zero.
+
+Basicamente não há dificuldade de engenharia significativa para serviços de terceiros como o Hiper.
+
+### Facilidade para os Usuários
+
+Vale notar que o uso de serviços de terceiros requer que os usuários se conectem a sistemas externos, o que pode envolver custos adicionais.
+
+Se os desenvolvedores usarem hole punching personalizado ou WebRTC, podem controlar completamente o aspecto da experiência do usuário.
+
+## Detalhes do Protocolo e Conceitos Básicos
+
+O protocolo consiste principalmente nas seguintes partes:
+
+1. Como estabelecer uma conexão ponto a ponto entre usuários.
+2. O formato do protocolo para comunicação entre usuários após uma conexão ponto a ponto ser estabelecida.
+3. Como permitir que o Minecraft se conecte através de um DataChannel.
+
+Aqui está uma breve introdução aos conceitos que aparecem no WebRTC e o que eles representam:
+
+### PeerConnection
+
+PeerConnection representa a conexão estabelecida com outros usuários.
+
+### DataChannel
+
+DataChannel representa o canal de comunicação de dados estabelecido com outros usuários em uma PeerConnection, similar a um Socket. Uma PeerConnection pode ter muitos DataChannels usados para diferentes tipos de comunicação. DataChannels podem ser criados/fechados arbitrariamente após uma PeerConnection ser estabelecida com sucesso.
+
+Ao criar um DataChannel, o `protocol` (protocolo) pode ser especificado. O listener remoto pode lidar com diferentes criações de DataChannel com base no `protocol`.
+
+### Description
+
+A Description é uma string criada pela PeerConnection para descrever as informações da rede local. Esta string contém algumas informações necessárias para o hole punching (já que o WebRTC fundamentalmente ainda requer hole punching).
+
+Os desenvolvedores não precisam entender completamente o conteúdo desta string; eles simplesmente precisam transmiti-la corretamente para o outro lado via servidor de sinalização.
+
+### ICEServer
+
+ICEServer é dividido em dois tipos: STUN e TURN.
+
+O WebRTC precisa obter informações de rede local de um servidor STUN para realizar o hole punching.
+
+Muitos servidores STUN são gratuitos, como o `stun:stun.qq.com` usado pelo QQ.
+
+Um servidor TURN é responsável por retransmitir o tráfego. Geralmente é auto-hospedado e requer pagamento.
+
+## 🔄 Fluxo de Conexão e Arquitetura de Sinalização
+
+O diagrama a seguir ilustra como a conexão P2P é coordenada, o hole punching NAT é completado e o tráfego do jogo é tunelado com segurança entre dois clientes Minecraft:
+
+<div style="margin: 24px 0; padding: 20px; border-radius: 12px; background: var(--vp-c-bg-soft); border: 1px solid var(--vp-c-divider);">
+<h3 style="margin-top: 0; margin-bottom: 16px; font-size: 1.1rem; font-weight: 600; color: var(--vp-c-text-1); display: flex; align-items: center; gap: 8px;">
+<span>🔄 Sequência de Conexão & Fluxo de Dados</span>
+</h3>
+<div style="display: flex; flex-direction: column; gap: 16px;">
+<!-- Passo 1 -->
+<div style="display: flex; gap: 16px;">
+<div style="flex-shrink: 0; width: 28px; height: 28px; border-radius: 50%; background: var(--vp-c-brand-1); color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.9rem;">1</div>
+<div>
+<strong style="color: var(--vp-c-text-1); display: block; margin-bottom: 4px;">Sinalização & Configuração da Sala</strong>
+<p style="margin: 0; font-size: 0.9rem; color: var(--vp-c-text-2);">
+<strong>Host</strong> envia SDP Offer ao Servidor de Lobby/Sinalização. <br/><strong>Convidado</strong> recupera o Offer, o define e retorna um SDP Answer de volta ao Host.
+</p>
+</div>
+</div>
+<!-- Seta -->
+<div style="margin-left: 14px; border-left: 2px dashed var(--vp-c-divider); height: 16px;"></div>
+<!-- Passo 2 -->
+<div style="display: flex; gap: 16px;">
+<div style="flex-shrink: 0; width: 28px; height: 28px; border-radius: 50%; background: var(--vp-c-brand-1); color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.9rem;">2</div>
+<div>
+<strong style="color: var(--vp-c-text-1); display: block; margin-bottom: 4px;">Traversal NAT & Hole Punching</strong>
+<p style="margin: 0; font-size: 0.9rem; color: var(--vp-c-text-2);">
+Ambos os launchers realizam hole punching STUN/TURN para estabelecer uma conexão Ponto a Ponto direta. Um canal de controle de metadados confiável é aberto.
+</p>
+</div>
+</div>
+<!-- Seta -->
+<div style="margin-left: 14px; border-left: 2px dashed var(--vp-c-divider); height: 16px;"></div>
+<!-- Passo 3 -->
+<div style="display: flex; gap: 16px;">
+<div style="flex-shrink: 0; width: 28px; height: 28px; border-radius: 50%; background: var(--vp-c-brand-1); color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.9rem;">3</div>
+<div>
+<strong style="color: var(--vp-c-text-1); display: block; margin-bottom: 4px;">Descoberta de Jogo LAN</strong>
+<p style="margin: 0; font-size: 0.9rem; color: var(--vp-c-text-2);">
+<strong>Minecraft do Host</strong> transmite seu mundo LAN. O launcher do Host encaminha esses metadados ao Convidado.<br/><strong>Launcher do Convidado</strong> cria um Proxy TCP local e o transmite como um jogo LAN falso para o cliente Minecraft do Convidado.
+</p>
+</div>
+</div>
+<!-- Seta -->
+<div style="margin-left: 14px; border-left: 2px dashed var(--vp-c-divider); height: 16px;"></div>
+<!-- Passo 4 -->
+<div style="display: flex; gap: 16px;">
+<div style="flex-shrink: 0; width: 28px; height: 28px; border-radius: 50%; background: var(--vp-c-brand-1); color: white; display: flex; align-items: center; justify-content: center; font-weight: 600; font-size: 0.9rem;">4</div>
+<div>
+<strong style="color: var(--vp-c-text-1); display: block; margin-bottom: 4px;">Tunelamento do Tráfego do Jogo</strong>
+<p style="margin: 0; font-size: 0.9rem; color: var(--vp-c-text-2);">
+O cliente do Convidado conecta ao proxy. O launcher do Convidado mapeia a conexão para um novo DataChannel WebRTC binário. O launcher do Host encaminha os pacotes para o servidor Minecraft real.
+</p>
+</div>
+</div>
+</div>
+</div>
+
+## Como estabelecer conexões entre usuários
+
+No WebRTC, as conexões entre usuários são estabelecidas através da troca de strings Description.
+
+Por exemplo, se A e B precisam estabelecer uma conexão, A como a parte iniciadora precisa:
+
+- Criar uma nova PeerConnection WebRTC
+- Escutar por mudanças de Description local e enviá-las para B através de um servidor de coordenação
+- Estabelecer um canal de dados com `protocol` definido como `metadata` para comunicação regular
+- Aguardar a Description de B
+
+Aqui está um exemplo de pseudo-código:
+
+```ts
+// "id" aqui representa o ID da pessoa com quem você quer se conectar, pode ser gerado arbitrariamente desde que seja único
+function initiateConnection(id: string) {
+    // criar uma nova conexão
+    let connection = new PeerConnection(id, {
+        iceServers: [
+            // Você pode usar seus próprios servidores STUN/TURN para ajudar a estabelecer a conexão
+            // Mas ter muitos servidores não é recomendado - geralmente 1-2 é suficiente
+            "stun:stun.qq.com",
+        ]
+        iceTransportPolicy: 'all',
+    });
+
+    // Algumas implementações WebRTC gerarão automaticamente uma Description local após criar um canal de dados
+    // Se sim, você só precisa escutar por mudanças de Description local
+    connection.onLocalDescription((description) => {
+        // Envie sua Description para a outra pessoa através do servidor de coordenação
+        sendDescription(id, description);
+    });
+
+    // Como iniciador, você precisa criar ativamente o canal de dados
+    const channel = connection.createDataChannel(id, {
+        ordered: true, // ordered significa que este canal é confiável
+        protocol: 'metadata'
+    })
+
+    // Comunique-se com o endpoint remoto através do canal no futuro
+}
+```
+
+Algumas implementações WebRTC não criam uma Description local automaticamente, nesse caso você deve criar um Offer e enviá-lo para a outra pessoa:
+
+```ts
+    const offer = await connection.createOffer()
+    sendDescription(id, offer);
+```
+
+B como receptor da conexão precisa criar uma PeerConnection após receber a Description de A. O processo é similar ao acima, e aqui está o pseudo-código:
+
+```ts
+function onGetOtherDescription(id: string, description: Description) {
+    let connection = new PeerConnection(id, {
+        iceServers,
+        iceTransportPolicy: 'all',
+    });
+
+    // Definir a Description remota diretamente
+    connection.setRemoteDescription(description);
+
+    // Escutar por criação de canal de dados
+    connection.onDataChannel((channel) => {
+        if (channel.protocol === 'metadata') {
+            // Este é o canal de metadados
+        }
+        // Você também pode lidar com canais de dados de muitos outros protocolos aqui
+    });
+
+    // Como o iniciador, quando uma Description local estiver disponível, envie para a outra pessoa
+    connection.onLocalDescription((description) => {
+        // Envie sua Description para a outra pessoa através do servidor de coordenação
+        sendDescription(id, description);
+    });
+}
+```
+
+Algumas implementações WebRTC não criam uma Description local automaticamente, nesse caso você deve criar um Answer e enviá-lo para a outra pessoa:
+
+```ts
+    const answer = await connection.createAnswer()
+    sendDescription(id, answer);
+```
+
+Quando o canal de dados de metadados entre ambas as partes é estabelecido com sucesso, a conexão também é estabelecida (hole punching bem-sucedido!). No entanto, você pode usar as mudanças de `ConnectionState` na PeerConnection para determinar o status da conexão.
+
+A maioria das implementações WebRTC tem os seguintes ConnectionState:
+
+- "closed" - A conexão está fechada.
+- "connected" - A conexão está estabelecida.
+- "connecting" - A conexão está sendo estabelecida.
+- "disconnected" - A conexão está desconectada.
+- "failed" - A conexão falhou.
+- "new" - A conexão acabou de ser criada.
+
+## Formato do Protocolo para Comunicação entre Usuários
+
+Após estabelecer uma PeerConnection, os usuários precisam se comunicar através de um DataChannel com `protocol` como `metadata`.
+
+O formato das informações de comunicação é uma string JSON UTF-8. O formato JSON da mensagem (doravante referida como Message) é:
+
+```ts
+interface Message {
+    type: string
+    payload: object
+}
+```
+
+Onde `type` representa diferentes tipos de mensagens e `type` determina o formato do payload.
+
+O seguinte **pseudo-código** mostra como enviar uma mensagem para a outra parte através do canal com `protocol` como `metadata`:
+
+```ts
+send<T>(type: string, payload: object) {
+    // Converte a mensagem para string JSON
+    const messageString = JSON.stringify({
+        type: type,
+        payload: payload
+    })
+    // Envia a string via canal de metadados
+    this.channel.sendMessage(messageString)
+}
+```
+
+### Mensagem de Heartbeat
+
+A mensagem de heartbeat é dividida em dois tipos: Ping e Pong.
+
+A mensagem Ping de heartbeat é enviada para a outra parte a cada segundo após a conexão ser estabelecida. A mensagem de heartbeat carrega um timestamp que pode ser usado para calcular o atraso entre você e a outra parte.
+
+O tipo da mensagem Ping é `heartbeat-ping`, e seu payload contém apenas uma propriedade, `time`. Um exemplo é o seguinte:
+
+```json
+{
+    "type": "heartbeat-ping",
+    "payload": {
+        "time": 12391724789
+    }
+}
+```
+
+Após receber uma mensagem Ping, você precisa enviar uma mensagem Pong de volta para a outra parte.
+O formato do Pong é igual ao da mensagem Ping, exceto que o `type` é `heartbeat-pong`. O `time` do Pong deve ser o mesmo que o do Ping.
+
+```json
+{
+    "type": "heartbeat-pong",
+    "payload": {
+        "time": 12391724789
+    }
+}
+```
+
+### Mensagem de Identidade do Jogador
+
+A mensagem de identidade do jogador é usada para atualizar o launcher para exibir o avatar, nome, etc. do jogador. O `payload` deve ser similar ao GameProfile do usuário do Minecraft.
+
+Entre eles, `textures` armazena as informações de skin do jogador, o que facilita o uso do authlib-injector para compartilhar as skins de todos.
+
+```json
+{
+    "type": "identity",
+    "payload": {
+        "name": "username",
+        "id": "user uuid",
+        "textures": {
+            "SKIN": {
+                "url": "skin url",
+                "metadata": { "model": "slim" }
+            }
+        }
+    }
+}
+```
+
+### Mensagem de Descoberta LAN do Minecraft
+
+Quando uma mensagem é recebida informando que um jogo do Minecraft na LAN publicou seu mundo, você deve enviar esta mensagem para outros usuários via DataChannel de metadados.
+
+Após receber esta mensagem, outros usuários devem criar um servidor proxy localmente e aguardar o Minecraft local se conectar.
+
+A seguir está o formato da mensagem:
+
+```json
+{
+    "type": "lan",
+    "payload": {
+        "motd": "motd do seu servidor",
+        "port": 34631
+    }
+}
+```
+
+`motd` é uma breve descrição do servidor, e `port` é o número da porta do Minecraft aberto para a LAN.
+
+## Como usar DataChannel para jogar Minecraft multiplayer
+
+Precisamos criar um protocolo DataChannel chamado `minecraft` para transmitir todo o tráfego do Minecraft.
+
+Após receber a mensagem de jogo LAN de outros usuários no Minecraft, o launcher precisa criar um servidor proxy local e enviar a porta do servidor proxy para o Minecraft local como um servidor LAN falso.
+
+O seguinte **pseudo-código** demonstra o processo:
+
+```ts
+function createMinecraftProxyServer(motd: string, port: number) {
+    // Criar um servidor proxy
+    const server = createServer((socket) => {
+        // Este socket é o socket quando o jogo Minecraft se conecta ao seu servidor proxy local.
+
+        // Este DataChannel precisa usar a porta esperada como label.
+        const gameChannel = this.connection.createDataChannel(port, {
+            protocol: 'minecraft', // Você precisa especificar o protocolo como minecraft.
+            order: true, // order representa confiabilidade.
+        })
+
+        // Escuta dados do Minecraft e os envia diretamente para a outra parte através do DataChannel
+        socket.on('data', (buf) => gameChannel.sendMessageBinary(buf))
+        // Escuta dados da outra parte e os alimenta diretamente para o Minecraft
+        gameChannel.onMessage((data) => socket.write(Buffer.from(data)))
+
+        // Quando uma parte fecha, fecha a outra também
+        socket.on('close', () => gameChannel.close())
+        gameChannel.onClosed(() => socket.destroy())
+    })
+
+    // Você precisa tentar fazer o servidor escutar na porta que precisa ser escutada
+    // A porta real do servidor proxy pode ser diferente da porta esperada.
+    const port = tryListenTo(server, info.port)
+
+    // Envia a porta real do servidor proxy e MOTD fingindo ser informações do Minecraft abertas para a LAN para o Minecraft local
+    broadcastLanMessageToMinecraft(info.motd, port)
+}
+```
+
+É importante notar que a porta do servidor criado localmente pode ser diferente da porta enviada da extremidade remota, e o launcher precisa manter este mapeamento de portas por conta própria.
+
+Após o servidor TCP proxy ser iniciado, o launcher precisa transmitir periodicamente este MOTD e porta para que o Minecraft atualize o jogo na lista de jogos LAN.
+
+Para a parte de compartilhamento do Minecraft no jogo LAN, eles precisam escutar a criação do DataChannel cujo protocolo é `minecraft`.
+O seguinte **pseudo-código** mostra como estabelecer uma conexão após escutar.
+
+```ts
+// Quando um novo DataChannel é criado
+this.connection.onDataChannel((channel) => {
+    // Quando o DataChannel é minecraft
+    if (channel.protocol === 'minecraft') {
+        // Obter a porta pelo label do canal
+        const port = Number.parseInt(channel.label)!
+
+        // Estabelecer uma conexão TCP com o número de porta correspondente na máquina local.
+        // Isso é equivalente a conectar ao servidor LAN do Minecraft aberto na máquina local.
+        const socket = createConnection(port)
+
+        // Escuta os dados desta conexão Minecraft e os envia diretamente para a parte remota.
+        socket.on('data', (buf) => channel.sendMessageBinary(buf))
+        // Escuta dados da extremidade remota e os encaminha diretamente para o Minecraft.
+        channel.onMessage((data) => socket.write(Buffer.from(data)))
+
+        // Quando uma parte fecha, fecha a outra também
+        socket.on('close', () => channel.close())
+        channel.onClosed(() => socket.destroy())
+    } else if (channel.protocol === 'metadata') {
+        // Lidar como canal de metadados
+    } else {
+        // Outros protocolos...
+    }
+})
+```
+
+Após o DataChannel `minecraft` ser estabelecido, uma parte entrou no jogo da outra!
+
+## Apêndice
+
+### Transmissão de Informações LAN do Minecraft
+
+As buscas LAN do Minecraft são implementadas através de multicast UDP, então o launcher só precisa enviar uma string no formato de
+
+```
+[MOTD]${motd}[/MOTD][AD]${port}[/AD]
+```
+
+para o endereço `224.0.2.60:4445` designado pelo Minecraft, onde `motd` é a descrição do servidor e `port` é a porta do servidor proxy.
+
+Por exemplo, se o servidor proxy está escutando na porta 28378 na sua máquina, você precisa enviar a seguinte string:
+
+```
+[MOTD]XXX Shared Server[/MOTD][AD]28378[/AD]
+```
+
+Escutar este pacote UDP é similar.
+
+### Relay
+
+Como estamos usando WebRTC, o servidor de relay é um servidor TURN padrão.
+
+Um servidor maduro como o [Coturn](https://github.com/coturn/coturn) pode ser usado como servidor de relay.
+
+Cada launcher pode configurar seu próprio serviço de relay.
+
+No launcher, apenas os `iceServers` da PeerConnection precisam ser configurados
+
+Por exemplo:
+
+```ts
+let connection = new PeerConnection(id, {
+    iceServers: [
+        {
+            urls: 'turn:meu-servidor-turn.minhaempresa.com:19403',
+            username: 'Seu nome de usuário no servidor TURN',
+            credentials: 'Token de login'
+        }
+    ],
+    iceTransportPolicy: 'all',
+});
+```
+
+Note que credenciais com contas de usuário e tokens de login podem ser adicionadas (porque relays são caros), e o launcher pode implementar autenticação de usuário para relays baseada em seu próprio sistema de contas.
+
+Portanto, o valor deste parâmetro `iceServers` pode precisar ser determinado dinamicamente com base no comportamento do usuário.
+
+### Servidor de coordenação
+
+Este artigo não limita a implementação de servidores de coordenação.
+
+O servidor de coordenação precisa trocar Description entre usuários para garantir que a PeerConnection possa estabelecer conexões.
+O servidor de lobby do launcher é basicamente o trabalho deste servidor de coordenação.
+
+WebSockets comuns podem ser usados para implementação, ou Sockets também podem ser implementados. Os usuários também podem copiar e enviar manualmente a Description um para o outro.
+
+Este aspecto não é discutido neste artigo.
+
+### Confiabilidade de transmissão
+
+Uma preocupação comum é se a transmissão de dados WebRTC é confiável, porque os jogos multiplayer do Minecraft usam o protocolo TCP, e a perda de pacotes não será tratada corretamente pelo Minecraft.
+
+Mas na verdade, o WebRTC suporta transmissão confiável e pode ser configurado ao criar o DataChannel. Veja a [documentação do MDN](https://developer.mozilla.org/pt-BR/docs/Web/API/RTCDataChannel/ordered).
+
+### IPV6?
+
+O WebRTC suporta IPV6.
+
+### Upnp?
+
+Algumas implementações WebRTC suportam Upnp.
+
+Um método simples é especificar um intervalo de portas para o WebRTC, e colocar as portas mapeadas na frente do intervalo.
+
+## Bibliotecas WebRTC
+
+- WebRTC para .NET C# - https://github.com/microsoft/winrtc
+- WebRTC binding para Java - https://github.com/devopvoid/webrtc-java
+- WebRTC binding para NodeJS - https://github.com/murat-dogan/node-datachannel
+- Implementação WebRTC em C - https://github.com/paullouisageneau/libdatachannel
+- Implementação WebRTC em Rust - https://github.com/lerouxrgd/datachannel-rs
+- Implementação WebRTC em Go - https://github.com/pion/webrtc


### PR DESCRIPTION
## Summary

- Adds a complete **Brazilian Portuguese (pt-BR)** locale to the XMCL documentation site
- Follows the same scope as the existing Spanish (`es`) locale
- The locale is auto-detected by the dynamic config system (reads `src/` directories)

## Files added

| File | Description |
|---|---|
| `locales/pt.yml` | All UI strings: nav, features catalog, footer, Linux & creators landing pages |
| `.vitepress/config.ts` | Added `pt` to `localesOrder` and `localeMetadata` with `hreflang: pt-BR` |
| `src/pt/index.md` | Home page |
| `src/pt/features/index.md` | Feature catalog |
| `src/pt/linux-minecraft-launcher.md` | Linux landing page |
| `src/pt/modpack-creator.md` | Modpack creators landing page |
| `src/pt/log-viewer.md` | Log viewer |
| `src/pt/prebuilds.md` | Prebuilds |
| `src/pt/guide/install.md` | Installation guide |
| `src/pt/guide/manage.md` | Data & storage management |
| `src/pt/guide/bedrock.md` | Bedrock Edition guide |
| `src/pt/guide/change-drive.md` | Moving data to another drive |
| `src/pt/guide/contributing.md` | Contributing guide |
| `src/pt/guide/i18n.md` | Localization guide |
| `src/pt/guide/microsoft-login-issues.md` | Microsoft login troubleshooting |
| `src/pt/guide/troubleshooting.md` | General troubleshooting |
| `src/pt/protocol/p2p.md` | WebRTC P2P protocol |

## Test plan

- [ ] Build the site with `pnpm build` — no errors expected
- [ ] Verify "Português (Brasil)" appears in the language switcher
- [ ] Navigate to `/pt/` — home page renders correctly
- [ ] Navigate to `/pt/guide/install` — sidebar and content render in Portuguese
- [ ] Verify `hreflang="pt-BR"` appears in page `<head>` for each pt page

🤖 Generated with [Claude Code](https://claude.com/claude-code)